### PR TITLE
Python 3 support

### DIFF
--- a/WikiParse.py
+++ b/WikiParse.py
@@ -2,8 +2,9 @@
 Final code for wiktionary parser.
 """
 from __future__ import unicode_literals
+from __future__ import absolute_import
 import re, requests
-from utils import WordData, Definition, RelatedWord
+from .utils import WordData, Definition, RelatedWord
 from bs4 import BeautifulSoup
 
 PARTS_OF_SPEECH = [


### PR DESCRIPTION
Python 2 & 3 support
```python
Python 3.5.1 (v3.5.1:37a07cee5969, Dec  6 2015, 01:54:25) [MSC v.1900 64 bit (AMD64)] on win32
Type "copyright", "credits" or "license()" for more information.
>>> from wiktionaryparser import WiktionaryParser
>>> parser = WiktionaryParser()
>>> word = parser.fetch('test')
>>> print(word)
[{'definitions': [{'relatedWords': ...
>>> another_word = parser.fetch('test','french')
>>> print(another_word)
[{'definitions': [{'relatedWords': [] ...
>>> parser.set_default_language('french')
```