### PR TITLE
don't crash if start_index is not found, just return an empty list

### DIFF
--- a/wiktionaryparser/WikiParse.py
+++ b/wiktionaryparser/WikiParse.py
@@ -79,6 +79,8 @@ class WiktionaryParser(object):
         for content in contents:
             if content.text.lower() == language:
                 start_index = content.find_previous().text + '.'
+        if not start_index:
+            return []
         for content in contents:
             index = content.find_previous().text
             if index.startswith(start_index):


### PR DESCRIPTION
My project mainly looks up English words but, since it processes dynamic web content, it occasionally looks up a word from another language but has no way of knowing in advance which language it is.  I ran into a case where WiktionaryParser looked up "Ramos" (Spanish) but did not find any `<span class="toctext">` tags matching English, causing this exception:
```TypeError: startswith first arg must be str or a tuple of str, not NoneType```
I think it's better to return no results than to crash.