### PR TITLE
tests fixed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.7.0
 beautifulsoup4==4.4.0
+deepdiff==3.3.0

--- a/tests/test.py
+++ b/tests/test.py
@@ -4,23 +4,29 @@ from deepdiff import DeepDiff
 
 parser = WiktionaryParser()
 
-class TestParser(unittest.TestCase): 
+class TestParser(unittest.TestCase):
     def test_multiple_languages(self):
         sample_output = {}
         with open('tests/testOutput.json', 'r') as f:
             sample_output = json.load(f)
         words_to_test = {
-            'English': ['grapple', 'test', 'patronise', 'abiologically', 'alexin', 'song', 'house'],
-            'Latin': ['video'],
-            'Norwegian Bokmål': ['seg', 'aldersblandet', 'by', 'for', 'admiral', 'heis', 'konkurs', 'pantergaupe', 'maldivisk'],
-            'Swedish': ['house'],
-            'Ancient Greek': ['ἀγγελία']
+            'English': {'grapple': 50080840, 'test': 50342756, 'patronise': 49023308, 'abiologically': 43781266, 'alexin': 50152026, 'song': 50235564, 'house': 50356446},
+            'Latin': {'video': 50291344},
+            'Norwegian Bokmål': {'seg': 50359832, 'aldersblandet': 38616917, 'by': 50399022, 'for': 50363295, 'admiral': 50357597, 'heis': 49469949, 'konkurs': 48269433, 'pantergaupe': 46717478, 'maldivisk': 49859434},
+            'Swedish': {'house': 50356446},
+            'Ancient Greek': {'ἀγγελία': 47719496}
         }
         for lang, words in words_to_test.items():
             parser.set_default_language(lang)
-            for word in words:
-                parsed_word = parser.fetch(word)
+            for word, oldid in words.items():
+                parsed_word = parser.fetch(word, oldid=oldid)
                 print("Testing \"{}\" in {}".format(word, lang))
                 self.assertEqual(DeepDiff(parsed_word, sample_output[lang][word], ignore_order=True), {})
+
+    def test_actual_or_archived(self):
+        self.assertEqual(parser.get_url('grapple', None), 'https://en.wiktionary.org/wiki/grapple?printable=yes')
+        self.assertEqual(parser.get_url('grapple', 50080840), 'https://en.wiktionary.org/wiki/grapple?printable=yes&oldid=50080840')
+        self.assertNotEqual(parser.fetch('grapple'), parser.fetch('grapple', oldid=50080840))
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -18,15 +18,10 @@ class TestParser(unittest.TestCase):
         }
         for lang, words in words_to_test.items():
             parser.set_default_language(lang)
-            for word, oldid in words.items():
-                parsed_word = parser.fetch(word, oldid=oldid)
+            for word, old_id in words.items():
+                parsed_word = parser.fetch(word, old_id=old_id)
                 print("Testing \"{}\" in {}".format(word, lang))
                 self.assertEqual(DeepDiff(parsed_word, sample_output[lang][word], ignore_order=True), {})
-
-    def test_actual_or_archived(self):
-        self.assertEqual(parser.get_url('grapple', None), 'https://en.wiktionary.org/wiki/grapple?printable=yes')
-        self.assertEqual(parser.get_url('grapple', 50080840), 'https://en.wiktionary.org/wiki/grapple?printable=yes&oldid=50080840')
-        self.assertNotEqual(parser.fetch('grapple'), parser.fetch('grapple', oldid=50080840))
 
 if __name__ == '__main__':
     unittest.main()

--- a/wiktionaryparser.py
+++ b/wiktionaryparser.py
@@ -72,12 +72,6 @@ class WiktionaryParser(object):
     def count_digits(self, string):
         return len(list(filter(str.isdigit, string)))
 
-    def get_url(self, word, oldid):
-        url_ = self.url.format(word)
-        if oldid:
-            url_ += '&oldid={}'.format(oldid)
-        return url_
-
     def get_id_list(self, contents, content_type):
         if content_type == 'etymologies':
             checklist = ['etymology']
@@ -257,10 +251,9 @@ class WiktionaryParser(object):
             json_obj_list.append(data_obj.to_json())
         return json_obj_list
 
-    def fetch(self, word, language=None, oldid=None):
+    def fetch(self, word, language=None, old_id=None):
         language = self.language if not language else language
-        url_ = self.get_url(word, oldid)
-        response = self.session.get(url_)
+        response = self.session.get(self.url, params={'oldid': old_id})
         self.soup = BeautifulSoup(response.text.replace('>\n<', '><'), 'html.parser')
         self.current_word = word
         self.clean_html()

--- a/wiktionaryparser.py
+++ b/wiktionaryparser.py
@@ -253,7 +253,7 @@ class WiktionaryParser(object):
 
     def fetch(self, word, language=None, old_id=None):
         language = self.language if not language else language
-        response = self.session.get(self.url, params={'oldid': old_id})
+        response = self.session.get(self.url.format(word), params={'oldid': old_id})
         self.soup = BeautifulSoup(response.text.replace('>\n<', '><'), 'html.parser')
         self.current_word = word
         self.clean_html()

--- a/wiktionaryparser.py
+++ b/wiktionaryparser.py
@@ -9,7 +9,7 @@ PARTS_OF_SPEECH = [
     "noun", "verb", "adjective", "adverb", "determiner",
     "article", "preposition", "conjunction", "proper noun",
     "letter", "character", "phrase", "proverb", "idiom",
-    "symbol", "syllable", "numeral", "initialism", "interjection", 
+    "symbol", "syllable", "numeral", "initialism", "interjection",
     "definitions", "pronoun",
 ]
 
@@ -41,7 +41,7 @@ class WiktionaryParser(object):
     def exclude_part_of_speech(self, part_of_speech):
         part_of_speech = part_of_speech.lower()
         self.PARTS_OF_SPEECH.remove(part_of_speech)
-        self.INCLUDED_ITEMS.remove(part_of_speech)        
+        self.INCLUDED_ITEMS.remove(part_of_speech)
 
     def include_relation(self, relation):
         relation = relation.lower()
@@ -71,6 +71,12 @@ class WiktionaryParser(object):
 
     def count_digits(self, string):
         return len(list(filter(str.isdigit, string)))
+
+    def get_url(self, word, oldid):
+        url_ = self.url.format(word)
+        if oldid:
+            url_ += '&oldid={}'.format(oldid)
+        return url_
 
     def get_id_list(self, contents, content_type):
         if content_type == 'etymologies':
@@ -251,9 +257,10 @@ class WiktionaryParser(object):
             json_obj_list.append(data_obj.to_json())
         return json_obj_list
 
-    def fetch(self, word, language=None):
+    def fetch(self, word, language=None, oldid=None):
         language = self.language if not language else language
-        response = self.session.get(self.url.format(word))
+        url_ = self.get_url(word, oldid)
+        response = self.session.get(url_)
         self.soup = BeautifulSoup(response.text.replace('>\n<', '><'), 'html.parser')
         self.current_word = word
         self.clean_html()


### PR DESCRIPTION
Adding a library (deepdiff) used in unit tests to _requirements.txt_

The unit tests no longer worked due to changes on the wiktionary. Adding a new parameter `oldid` to keep the state of the page as it was when the tests were written.