### PR TITLE
Reference the license

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,3 +64,7 @@ Right now, it parses etymologies, definitions, pronunciations, examples, audio l
 #### Contributions
 
 If you want to add features/improvement or report issues, feel free to send a pull request!
+
+#### License
+
+Wiktionary Parser is licensed under [MIT](LICENSE.txt).

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,6 @@ setup(
   install_requires = ['beautifulsoup4','requests'],
   classifiers=[
    'Development Status :: 5 - Production/Stable',
+   'License :: OSI Approved :: MIT License',
   ],
 )


### PR DESCRIPTION
Reference the license in the _readme.md_ and _setup.py,_ following #16 and #50.