### PR TITLE
Added working support for French Wiktionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 wiktionaryparser/notes.txt
 notes.txt
+tests.ipynb
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ Only English and French Wiktionaries are supported.
 >>> parser.set_default_language('french')
 >>> parser.exclude_part_of_speech('noun')
 >>> parser.include_relation('alternative forms')
->>> 
+
 >>> parser_fr = WiktionaryParser(language="français")
 >>> word = parser_fr.fetch('test')
 >>> word = parser_fr.fetch('test', 'anglais')
@@ -72,4 +72,4 @@ If you want to add features/improvement or report issues, feel free to send a pu
 
 #### License
 
-Wiktionary Parser is licensed under [MIT](LICENSE.txt).
+    Wiktionary Parser is licensed under [MIT](LICENSE.txt).

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 
 A python project which parses word content from Wiktionary in an easy to use JSON format.
 Right now, it parses etymologies, definitions, pronunciations, examples, audio links and related words.
+Only English and French Wiktionaries are supported.
 
 [![Downloads](http://pepy.tech/badge/wiktionaryparser)](http://pepy.tech/project/wiktionaryparser)
 
@@ -54,6 +55,10 @@ Right now, it parses etymologies, definitions, pronunciations, examples, audio l
 >>> parser.set_default_language('french')
 >>> parser.exclude_part_of_speech('noun')
 >>> parser.include_relation('alternative forms')
+>>> 
+>>> parser_fr = WiktionaryParser(language="français")
+>>> word = parser_fr.fetch('test')
+>>> word = parser_fr.fetch('test', 'anglais')
 ```
 
 #### Requirements

--- a/wiktionaryparser.py
+++ b/wiktionaryparser.py
@@ -53,7 +53,7 @@ def is_subheading(child, parent):
 
 
 class WiktionaryParser(object):
-    def __init__(self, language="français"):
+    def __init__(self, language="english"):
         self.soup = None
         self.session = requests.Session()
         self.session.mount("http://", requests.adapters.HTTPAdapter(max_retries=2))
@@ -67,6 +67,8 @@ class WiktionaryParser(object):
             self.RELATIONS = copy(RELATIONS["français"])
             self.INCLUDED_ITEMS = self.RELATIONS + self.PARTS_OF_SPEECH + ['étymologie', 'prononciation']
         else:
+            if language != "english":
+                print("language unsupported, switched to english")
             self.language = 'english'
             self.url = "https://en.wiktionary.org/wiki/{}?printable=yes"
             self.PARTS_OF_SPEECH = copy(PARTS_OF_SPEECH["english"])


### PR DESCRIPTION
I hardcoded support for French Wiktionary.
The parser will parse French Wiktionary instead of English Wiktionary if it is initialized with the parameter `language` set to `français`, as in
>>> parser_fr = WiktionaryParser(language="français")

If the parameter is not given, the behaviour should be the same as it is right now.