### PR TITLE
Fix sub-definitions not being listed

### DIFF
--- a/tests/testOutput.json
+++ b/tests/testOutput.json
@@ -117,7 +117,11 @@
                         "partOfSpeech": "noun",
                         "text": [
                             "grapple (countable and uncountable, plural grapples)",
-                            "A tool with claws or hooks which is used to catch or hold something.",
+                            [
+                                "A tool with claws or hooks which is used to catch or hold something.",
+                                "(nautical) A device consisting of iron claws, attached to the end of a rope, used for grasping and holding an enemy ship prior to boarding; a grappling iron.",
+                                "(nautical) A grapnel (“type of anchor”)."
+                            ],
                             "A close hand-to-hand struggle.",
                             "(uncountable) The act of grappling."
                         ],
@@ -156,7 +160,11 @@
                             "house (countable and uncountable, plural houses or (dialectal) housen or (chiefly humorous) hice)",
                             "A structure built or serving as an abode of human beings. [from 9thc.]",
                             "The people who live in a house; a household. [from 9thc.]",
-                            "A building used for something other than a residence (typically with qualifying word). [from 10thc.]",
+                            [
+                                "A building used for something other than a residence (typically with qualifying word). [from 10thc.]",
+                                "A place of business; a company or organisation, especially a printing press, a publishing company, or a couturier. [from 10thc.]",
+                                "A place of public accommodation or entertainment, especially a public house, an inn, a restaurant, a theatre, or a casino; or the management thereof.[from 10thc.]"
+                            ],
                             "The audience for a live theatrical or similar performance. [from 10thc.]",
                             "(politics) A building where a deliberative assembly meets; whence the assembly itself, particularly a component of a legislature. [from 10thc.]",
                             "A dynasty; a family with its ancestors and descendants, especially a royal or noble one. [from 10thc.]",

--- a/wiktionaryparser/core.py
+++ b/wiktionaryparser/core.py
@@ -178,10 +178,11 @@ class WiktionaryParser(object):
                         if element.text:
                             sub_definitions = element.find_all("li")
                             if sub_definitions:
-                                top_definition = element.text.split('\n')[0].strip()
-                                definitions_list = [sub_definition.text.strip() for sub_definition in sub_definitions]
-                                definitions_list.insert(0, top_definition)
-                                definition_text.append(definitions_list)
+                                element.find("ol").extract()
+                                top_definition = element.text.strip()
+                                sub_definitions_list = [sub_definition.text.strip() for sub_definition in sub_definitions]
+                                sub_definitions_list.insert(0, top_definition)
+                                definition_text.append(sub_definitions_list)
                             else:
                                 definition_text.append(element.text.strip())
             if def_type == 'definitions':

--- a/wiktionaryparser/core.py
+++ b/wiktionaryparser/core.py
@@ -176,7 +176,14 @@ class WiktionaryParser(object):
                 if definition_tag.name in ['ol', 'ul']:
                     for element in definition_tag.find_all('li', recursive=False):
                         if element.text:
-                            definition_text.append(element.text.strip())
+                            sub_definitions = element.find_all("li")
+                            if sub_definitions:
+                                top_definition = element.text.split('\n')[0].strip()
+                                definitions_list = [sub_definition.text.strip() for sub_definition in sub_definitions]
+                                definitions_list.insert(0, top_definition)
+                                definition_text.append(definitions_list)
+                            else:
+                                definition_text.append(element.text.strip())
             if def_type == 'definitions':
                 def_type = ''
             definition_list.append((def_index, definition_text, def_type))

--- a/wiktionaryparser/core.py
+++ b/wiktionaryparser/core.py
@@ -198,7 +198,7 @@ class WiktionaryParser(object):
                         examples.append(example_text)
                     element.clear()
                 example_list.append((def_index, examples, def_type))
-                for quot_list in table.find_all(['ul', 'ol']):
+                for quot_list in table.find_all("ul", recursive=True):
                     quot_list.clear()
                 table = table.find_next_sibling()
         return example_list


### PR DESCRIPTION
Previously, a word that had a layered definition, such as:

<img width="935" alt="Screenshot 2020-09-09 at 19 18 18" src="https://user-images.githubusercontent.com/44314433/92625430-4badf600-f2d1-11ea-8597-2866d05cec4d.png">

would return the following definition:

```
['grapple (countable and uncountable, plural grapples)',
 'A tool with claws or hooks which is used to catch or hold something.',
 'A close hand-to-hand struggle.',
 '(uncountable) The act of grappling.']
```

So the sub-definitions of `A tool with claws or hooks which is used to catch or hold something.` weren't listed.

This PR makes it so the returned definition becomes:

```
['grapple (countable and uncountable, plural grapples)',
 ['A tool with claws or hooks which is used to catch or hold something.',
  '(nautical) A device consisting of iron claws, attached to the end of a rope, used for grasping and holding an enemy ship prior to boarding; a grappling iron.',
  '(nautical) A grapnel (“type of anchor”).'],
 'A close hand-to-hand struggle.',
 '(uncountable) The act of grappling.']
```

thus fixing #57.

However, this structure (using arrays to depict a layered definition, where the first element represents the top-level definition) may not be the most ideal one. Not sure.

This causes two of the tests to fail (`grapple` and `house`), as they both have such sub-definitions that were previously ignored.