### PR TITLE
Handle edge case of empty definition

### DIFF
--- a/tests/html_test_files/correspondent-61052028.html
+++ b/tests/html_test_files/correspondent-61052028.html
@@ -1,0 +1,483 @@
+<!DOCTYPE html>
+<html class="client-nojs" lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8"/>
+<title>correspondent - Wiktionary</title>
+<script>document.documentElement.className="client-js";RLCONF={"wgBreakFrames":!1,"wgSeparatorTransformTable":["",""],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"dmy","wgMonthNames":["","January","February","March","April","May","June","July","August","September","October","November","December"],"wgRequestId":"04dfb7e8-7d08-433d-ae5a-30a54e72d129","wgCSPNonce":!1,"wgCanonicalNamespace":"","wgCanonicalSpecialPageName":!1,"wgNamespaceNumber":0,"wgPageName":"correspondent","wgTitle":"correspondent","wgCurRevisionId":61052028,"wgRevisionId":61052028,"wgArticleId":229376,"wgIsArticle":!0,"wgIsRedirect":!1,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":["Tea room","Requests for attention concerning English","Russian redlinks","Russian redlinks/t+","Requests for review of Bulgarian translations","Requests for review of Manx translations","Requests for review of Norman translations","Requests for etymologies in Norman entries",
+"English terms derived from Latin","English terms derived from Middle French","English terms derived from Medieval Latin","English 4-syllable words","English terms with IPA pronunciation","English terms with audio links","English lemmas","English adjectives","English terms with quotations","English nouns","English countable nouns","en:People","Dutch terms borrowed from Middle French","Dutch terms derived from Middle French","Dutch terms derived from Latin","Dutch terms with IPA pronunciation","Dutch terms with audio links","Dutch lemmas","Dutch nouns","Dutch nouns with plural in -en","Dutch masculine nouns","French 3-syllable words","French terms with IPA pronunciation","French non-lemma forms","French verb forms","Latin non-lemma forms","Latin verb forms","Norman lemmas","Norman nouns","Norman masculine nouns","Jersey Norman"],"wgPageContentLanguage":"en","wgPageContentModel":"wikitext","wgRelevantPageName":"correspondent","wgRelevantArticleId":229376,"wgIsProbablyEditable":!0,
+"wgRelevantPageIsProbablyEditable":!0,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgMediaViewerOnClick":!0,"wgMediaViewerEnabledByDefault":!0,"wgVisualEditor":{"pageLanguageCode":"en","pageLanguageDir":"ltr","pageVariantFallbacks":"en"},"wgMFDisplayWikibaseDescriptions":{"search":!0,"nearby":!0,"watchlist":!0,"tagline":!1},"wgWMESchemaEditAttemptStepOversample":!1,"wgULSCurrentAutonym":"English","wgNoticeProject":"wiktionary","wgCentralAuthMobileDomain":!1,"wgEditSubmitButtonLabelPublish":!0,"wgULSPosition":"interlanguage"};RLSTATE={"ext.gadget.column-hacks":"ready","ext.globalCssJs.user.styles":"ready","site.styles":"ready","noscript":"ready","user.styles":"ready","ext.globalCssJs.user":"ready","user":"ready","user.options":"loading","ext.tmh.thumbnail.styles":"ready","skins.vector.styles.legacy":"ready","mediawiki.toc.styles":"ready","ext.visualEditor.desktopArticleTarget.noscript":"ready","ext.uls.interlanguage":"ready","ext.wikimediaBadges":"ready"};
+RLPAGEMODULES=["mw.MediaWikiPlayer.loader","mw.PopUpMediaTransform","mw.TMHGalleryHook.js","site","mediawiki.page.ready","mediawiki.toc","skins.vector.legacy.js","ext.gadget.LegacyScripts","ext.gadget.JavascriptHeadings","ext.gadget.TargetedTranslations","ext.gadget.DocTabs","ext.gadget.BlockInfo","ext.gadget.RevdelInfo","ext.gadget.CodeLinks","ext.gadget.TranslationAdder","ext.gadget.RhymesAdder","ext.gadget.SpecialSearch","ext.gadget.zhDialMap","ext.gadget.catfix","ext.gadget.Edittools","ext.gadget.defaultVisibilityToggles","ext.centralauth.centralautologin","mmv.head","mmv.bootstrap.autostart","ext.visualEditor.desktopArticleTarget.init","ext.visualEditor.targetLoader","ext.eventLogging","ext.wikimediaEvents","ext.navigationTiming","ext.uls.compactlinks","ext.uls.interface","ext.centralNotice.geoIP","ext.centralNotice.startUp"];</script>
+<script>(RLQ=window.RLQ||[]).push(function(){mw.loader.implement("user.options@1hzgi",function($,jQuery,require,module){/*@nomin*/mw.user.tokens.set({"patrolToken":"+\\","watchToken":"+\\","csrfToken":"+\\"});
+});});</script>
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=ext.tmh.thumbnail.styles%7Cext.uls.interlanguage%7Cext.visualEditor.desktopArticleTarget.noscript%7Cext.wikimediaBadges%7Cmediawiki.toc.styles%7Cskins.vector.styles.legacy&amp;only=styles&amp;skin=vector"/>
+<script async="" src="/w/load.php?lang=en&amp;modules=startup&amp;only=scripts&amp;raw=1&amp;skin=vector"></script>
+<meta name="ResourceLoaderDynamicStyles" content=""/>
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=ext.gadget.column-hacks&amp;only=styles&amp;skin=vector"/>
+<link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=site.styles&amp;only=styles&amp;skin=vector"/>
+<meta name="generator" content="MediaWiki 1.36.0-wmf.16"/>
+<meta name="referrer" content="origin"/>
+<meta name="referrer" content="origin-when-crossorigin"/>
+<meta name="referrer" content="origin-when-cross-origin"/>
+<link rel="preconnect" href="//upload.wikimedia.org"/>
+<link rel="alternate" media="only screen and (max-width: 720px)" href="//en.m.wiktionary.org/wiki/correspondent"/>
+<link rel="alternate" type="application/x-wiki" title="Edit" href="/w/index.php?title=correspondent&amp;action=edit"/>
+<link rel="edit" title="Edit" href="/w/index.php?title=correspondent&amp;action=edit"/>
+<link rel="apple-touch-icon" href="/static/apple-touch/wiktionary/en.png"/>
+<link rel="shortcut icon" href="/static/favicon/wiktionary/en.ico"/>
+<link rel="search" type="application/opensearchdescription+xml" href="/w/opensearch_desc.php" title="Wiktionary (en)"/>
+<link rel="EditURI" type="application/rsd+xml" href="//en.wiktionary.org/w/api.php?action=rsd"/>
+<link rel="license" href="//creativecommons.org/licenses/by-sa/3.0/"/>
+<link rel="canonical" href="https://en.wiktionary.org/wiki/correspondent"/>
+<link rel="dns-prefetch" href="//login.wikimedia.org"/>
+<link rel="dns-prefetch" href="//meta.wikimedia.org" />
+</head>
+<body class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable page-correspondent rootpage-correspondent skin-vector action-view skin-vector-legacy"><div id="mw-page-base" class="noprint"></div>
+<div id="mw-head-base" class="noprint"></div>
+<div id="content" class="mw-body" role="main">
+	<a id="top"></a>
+	<div id="siteNotice" class="mw-body-content"><!-- CentralNotice --></div>
+	<div class="mw-indicators mw-body-content">
+	</div>
+	<h1 id="firstHeading" class="firstHeading" lang="en">correspondent</h1>
+	<div id="bodyContent" class="mw-body-content">
+		<div id="siteSub" class="noprint">Definition from Wiktionary, the free dictionary</div>
+		<div id="contentSub"></div>
+		<div id="contentSub2"></div>
+
+		<div id="jump-to-nav"></div>
+		<a class="mw-jump-link" href="#mw-head">Jump to navigation</a>
+		<a class="mw-jump-link" href="#searchInput">Jump to search</a>
+		<div id="mw-content-text" lang="en" dir="ltr" class="mw-content-ltr"><div class="mw-parser-output"><div id="toc" class="toc" role="navigation" aria-labelledby="mw-toc-heading"><input type="checkbox" role="button" id="toctogglecheckbox" class="toctogglecheckbox" style="display:none" /><div class="toctitle" lang="en" dir="ltr"><h2 id="mw-toc-heading">Contents</h2><span class="toctogglespan"><label class="toctogglelabel" for="toctogglecheckbox"></label></span></div>
+<ul>
+<li class="toclevel-1 tocsection-1"><a href="#English"><span class="tocnumber">1</span> <span class="toctext">English</span></a>
+<ul>
+<li class="toclevel-2 tocsection-2"><a href="#Etymology"><span class="tocnumber">1.1</span> <span class="toctext">Etymology</span></a></li>
+<li class="toclevel-2 tocsection-3"><a href="#Pronunciation"><span class="tocnumber">1.2</span> <span class="toctext">Pronunciation</span></a></li>
+<li class="toclevel-2 tocsection-4"><a href="#Adjective"><span class="tocnumber">1.3</span> <span class="toctext">Adjective</span></a>
+<ul>
+<li class="toclevel-3 tocsection-5"><a href="#Translations"><span class="tocnumber">1.3.1</span> <span class="toctext">Translations</span></a></li>
+</ul>
+</li>
+<li class="toclevel-2 tocsection-6"><a href="#Noun"><span class="tocnumber">1.4</span> <span class="toctext">Noun</span></a>
+<ul>
+<li class="toclevel-3 tocsection-7"><a href="#Hyponyms"><span class="tocnumber">1.4.1</span> <span class="toctext">Hyponyms</span></a></li>
+<li class="toclevel-3 tocsection-8"><a href="#Derived_terms"><span class="tocnumber">1.4.2</span> <span class="toctext">Derived terms</span></a></li>
+<li class="toclevel-3 tocsection-9"><a href="#Translations_2"><span class="tocnumber">1.4.3</span> <span class="toctext">Translations</span></a></li>
+</ul>
+</li>
+<li class="toclevel-2 tocsection-10"><a href="#See_also"><span class="tocnumber">1.5</span> <span class="toctext">See also</span></a></li>
+<li class="toclevel-2 tocsection-11"><a href="#References"><span class="tocnumber">1.6</span> <span class="toctext">References</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-12"><a href="#Dutch"><span class="tocnumber">2</span> <span class="toctext">Dutch</span></a>
+<ul>
+<li class="toclevel-2 tocsection-13"><a href="#Alternative_forms"><span class="tocnumber">2.1</span> <span class="toctext">Alternative forms</span></a></li>
+<li class="toclevel-2 tocsection-14"><a href="#Etymology_2"><span class="tocnumber">2.2</span> <span class="toctext">Etymology</span></a></li>
+<li class="toclevel-2 tocsection-15"><a href="#Pronunciation_2"><span class="tocnumber">2.3</span> <span class="toctext">Pronunciation</span></a></li>
+<li class="toclevel-2 tocsection-16"><a href="#Noun_2"><span class="tocnumber">2.4</span> <span class="toctext">Noun</span></a>
+<ul>
+<li class="toclevel-3 tocsection-17"><a href="#Related_terms"><span class="tocnumber">2.4.1</span> <span class="toctext">Related terms</span></a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-18"><a href="#French"><span class="tocnumber">3</span> <span class="toctext">French</span></a>
+<ul>
+<li class="toclevel-2 tocsection-19"><a href="#Pronunciation_3"><span class="tocnumber">3.1</span> <span class="toctext">Pronunciation</span></a></li>
+<li class="toclevel-2 tocsection-20"><a href="#Verb"><span class="tocnumber">3.2</span> <span class="toctext">Verb</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-21"><a href="#Latin"><span class="tocnumber">4</span> <span class="toctext">Latin</span></a>
+<ul>
+<li class="toclevel-2 tocsection-22"><a href="#Verb_2"><span class="tocnumber">4.1</span> <span class="toctext">Verb</span></a></li>
+</ul>
+</li>
+<li class="toclevel-1 tocsection-23"><a href="#Norman"><span class="tocnumber">5</span> <span class="toctext">Norman</span></a>
+<ul>
+<li class="toclevel-2 tocsection-24"><a href="#Etymology_3"><span class="tocnumber">5.1</span> <span class="toctext">Etymology</span></a></li>
+<li class="toclevel-2 tocsection-25"><a href="#Noun_3"><span class="tocnumber">5.2</span> <span class="toctext">Noun</span></a></li>
+</ul>
+</li>
+</ul>
+</div>
+
+<h2><span class="mw-headline" id="English">English</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=1" title="Edit section: English">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<h3><span class="mw-headline" id="Etymology">Etymology</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=2" title="Edit section: Etymology">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>From <span class="etyl"><a href="https://en.wikipedia.org/wiki/Latin" class="extiw" title="w:Latin">Latin</a></span>, via <span class="etyl"><a href="https://en.wikipedia.org/wiki/Middle_French" class="extiw" title="w:Middle French">Middle French</a></span> or directly, from <span class="etyl"><a href="https://en.wikipedia.org/wiki/Medieval_Latin" class="extiw" title="w:Medieval Latin">Medieval Latin</a></span> <i class="Latn mention" lang="la"><a href="/wiki/correspondens#Latin" title="correspondens">correspondēns</a></i>, present participle of <i class="Latn mention" lang="la"><a href="/wiki/correspondeo#Latin" title="correspondeo">correspondeō</a></i>.
+</p>
+<h3><span class="mw-headline" id="Pronunciation">Pronunciation</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=3" title="Edit section: Pronunciation">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<ul><li><span class="ib-brac qualifier-brac">(</span><span class="ib-content qualifier-content"><a href="https://en.wikipedia.org/wiki/Received_Pronunciation" class="extiw" title="w:Received Pronunciation">Received Pronunciation</a></span><span class="ib-brac qualifier-brac">)</span> <a href="/wiki/Wiktionary:International_Phonetic_Alphabet" title="Wiktionary:International Phonetic Alphabet">IPA</a><sup>(<a href="/wiki/Appendix:English_pronunciation" title="Appendix:English pronunciation">key</a>)</sup>:&#32;<span class="IPA">/ˌkɒɹɪˈspɒndənt/</span></li>
+<li><span class="ib-brac qualifier-brac">(</span><span class="ib-content qualifier-content"><a href="https://en.wikipedia.org/wiki/General_American" class="extiw" title="w:General American">General American</a></span><span class="ib-brac qualifier-brac">)</span> <a href="/wiki/Wiktionary:International_Phonetic_Alphabet" title="Wiktionary:International Phonetic Alphabet">IPA</a><sup>(<a href="/wiki/Appendix:English_pronunciation" title="Appendix:English pronunciation">key</a>)</sup>:&#32;<span class="IPA">/ˌkɔɹɪˈspɑndənt/</span></li>
+<li><style data-mw-deduplicate="TemplateStyles:r50165410">.mw-parser-output .k-player .k-attribution{visibility:hidden}</style><table class="audiotable" style="vertical-align: bottom; display:inline-block; list-style:none;line-height: 1em; border-collapse:collapse;"><tbody><tr><td class="unicode audiolink" style="padding-right:5px; padding-left: 0;">Audio (US)</td><td class="audiofile"><div class="mediaContainer" style="width:175px"><audio id="mwe_player_0" controls="" preload="none" style="width:175px" class="kskin" data-durationhint="1.0472789115646" data-startoffset="0" data-mwtitle="En-us-correspondent.ogg" data-mwprovider="wikimediacommons"><source src="//upload.wikimedia.org/wikipedia/commons/transcoded/5/58/En-us-correspondent.ogg/En-us-correspondent.ogg.mp3" type="audio/mpeg" data-title="MP3" data-shorttitle="MP3" data-transcodekey="mp3" data-width="0" data-height="0" data-bandwidth="137336" /><source src="//upload.wikimedia.org/wikipedia/commons/5/58/En-us-correspondent.ogg" type="audio/ogg; codecs=&quot;vorbis&quot;" data-title="Original Ogg file (275 kbps)" data-shorttitle="Ogg source" data-width="0" data-height="0" data-bandwidth="274746" /></audio></div></td><td class="audiometa" style="font-size: 80%;">(<a href="/wiki/File:En-us-correspondent.ogg" title="File:En-us-correspondent.ogg">file</a>)</td></tr></tbody></table></li></ul>
+<h3><span class="mw-headline" id="Adjective">Adjective</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=4" title="Edit section: Adjective">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<div class="noprint maintenance-box maintenance-box-blue" style="background:#EEEEFF; width:90%; margin: 0.75em auto; border:1px dashed #4444AA; padding: 0.25em;">
+<table>
+<tbody><tr>
+<td rowspan="2"><a href="/wiki/File:Teacup_clipart.svg" class="image"><img alt="Teacup clipart.svg" src="//upload.wikimedia.org/wikipedia/commons/thumb/e/e8/Teacup_clipart.svg/60px-Teacup_clipart.svg.png" decoding="async" width="60" height="47" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/e/e8/Teacup_clipart.svg/90px-Teacup_clipart.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/e/e8/Teacup_clipart.svg/120px-Teacup_clipart.svg.png 2x" data-file-width="672" data-file-height="522" /></a>
+</td>
+<th style="text-align: left;">The <a href="/wiki/Wiktionary:Tea_room/2019/November#correspondent" title="Wiktionary:Tea room/2019/November">Tea room</a><b><sup style="font-weight: normal" class="plainlinks" title="Start discussion">(<a class="external text" href="https://en.wiktionary.org/wiki/Wiktionary:Tea_room/2020/November?action=edit&amp;section=new&amp;preloadtitle=%5B%5Bcorrespondent%5D%5D">+</a>)</sup> is discussing this entry at the moment.</b>
+</th></tr>
+<tr>
+<td>Please come along and share your opinions on this and the <a href="/wiki/Category:Tea_room" title="Category:Tea room">other topics</a> being discussed there.
+</td></tr></tbody></table></div><p><span id="attentionseekingen" class="attentionseeking" lang="en" title="see Tea room discussion"></span>
+</p><p><strong class="Latn headword" lang="en">correspondent</strong> (<i><a href="/wiki/Appendix:Glossary#comparative" title="Appendix:Glossary">comparative</a></i> <b class="Latn form-of lang-en comparative-form-of" lang="en"><a href="/wiki/more#English" title="more">more</a> correspondent</b>, <i><a href="/wiki/Appendix:Glossary#superlative" title="Appendix:Glossary">superlative</a></i> <b class="Latn form-of lang-en superlative-form-of" lang="en"><a href="/wiki/most#English" title="most">most</a> correspondent</b>)
+</p>
+<ol><li><a href="/wiki/corresponding" title="corresponding">Corresponding</a>; suitable; adapted; congruous.
+<ul><li><b>1594</b>, <a href="https://en.wikipedia.org/wiki/Richard_Hooker" class="extiw" title="wikipedia:Richard Hooker">Richard Hooker</a>, <i>Of the Lawes of Ecclesiastical Politie</i>
+<dl><dd>Action <b>correspondent</b> or repugnant unto the law.</dd></dl></li>
+<li><div class="citation-whole"><span class="cited-source"><b>1577</b>,  “Constantinus the Emperour Summoneth the Nicene Councell”, in <a href="https://en.wikipedia.org/wiki/Meredith_Hanmer" class="extiw" title="wikipedia:Meredith Hanmer">Meredith Hanmer</a>, transl., <cite>The Avncient Ecclesiasticall Histories of the First Six Hundred Yeares after Christ</cite>, translation of original by <a href="https://en.wikipedia.org/wiki/Eusebius" class="extiw" title="w:Eusebius">Eusebius Pamphilus</a>, <a rel="nofollow" class="external text" href="https://archive.org/stream/aunciente00euse#page/n224/mode/1up">page 225</a>:</span><dl><dd><div class="h-quotation"><span class="Latn e-quotation" lang="en">[VV]e are able with playne demonſtration to proue, and vvith reaſon to perſvvade that in tymes paſt our fayth vvas alike, that then vve preached thinges <b>correſpondent</b> vnto the forme of faith already published of vs, ſo that none in this behalfe can repyne or gaynesay vs.</span></div></dd></dl></div></li></ul></li>
+<li><span class="ib-brac">(</span><span class="ib-content">with to or with</span><span class="ib-brac">)</span> <a href="/wiki/conforming" title="conforming">Conforming</a>; obedient.
+<ul><li><b>1610</b>, <i><a href="https://en.wikisource.org/wiki/The_Tempest" class="extiw" title="s:The Tempest">The Tempest</a></i>, by <a href="https://en.wikipedia.org/wiki/William_Shakespeare" class="extiw" title="w:William Shakespeare">Shakespeare</a>, act 1 scene 2
+<dl><dd><a href="https://en.wikipedia.org/wiki/Ariel_(The_Tempest)" class="extiw" title="w:Ariel (The Tempest)">ARIEL</a>: Pardon, master: / I will be <b>correspondent</b> to command, / And do my <a href="/wiki/spriting" title="spriting">spriting</a> gently.</dd></dl></li></ul></li></ol>
+<h4><span class="mw-headline" id="Translations">Translations</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=5" title="Edit section: Translations">edit</a><span class="mw-editsection-bracket">]</span></span></h4>
+<div class="pseudo NavFrame"><div class="NavHead" style="text-align: left;">corresponding <span style="font-weight: normal">— <i>see</i></span> <a href="/wiki/corresponding" title="corresponding">corresponding</a></div></div>
+<div class="NavFrame" id="Translations-conforming">
+<div class="NavHead" style="text-align:left;">conforming</div>
+<div class="NavContent">
+<table class="translations" role="presentation" style="width:100%;" data-gloss="conforming">
+
+<tbody><tr>
+<td class="translations-cell" style="background-color:#ffffe0; vertical-align:top; width:48%; text-align:left;">
+<ul><li>Bulgarian: <span class="Cyrl" lang="bg"><a href="/wiki/%D1%81%D1%8A%D0%BE%D1%82%D0%B2%D0%B5%D1%82%D0%B5%D0%BD#Bulgarian" title="съответен">съответен</a></span><span class="tpos">&#160;<a href="https://bg.wiktionary.org/wiki/%D1%81%D1%8A%D0%BE%D1%82%D0%B2%D0%B5%D1%82%D0%B5%D0%BD" class="extiw" title="bg:съответен">(bg)</a></span> <span class="mention-gloss-paren annotation-paren">(</span><span lang="bg-Latn" class="tr Latn">sǎotveten</span><span class="mention-gloss-paren annotation-paren">)</span></li>
+<li>Dutch: <span class="Latn" lang="nl"><a href="/wiki/overeenkomend#Dutch" title="overeenkomend">overeenkomend</a></span><span class="tpos">&#160;<a href="https://nl.wiktionary.org/wiki/overeenkomend" class="extiw" title="nl:overeenkomend">(nl)</a></span>, <span class="Latn" lang="nl"><a href="/wiki/overeenstemmend#Dutch" title="overeenstemmend">overeenstemmend</a></span><span class="tpos">&#160;<a href="https://nl.wiktionary.org/wiki/overeenstemmend" class="extiw" title="nl:overeenstemmend">(nl)</a></span></li></ul>
+</td>
+<td style="width:1%;">
+</td>
+<td class="translations-cell" style="background-color:#ffffe0; vertical-align:top; text-align:left; width:48%;">
+<ul><li>Russian: <span class="Cyrl" lang="ru"><a href="/wiki/%D1%81%D0%BE%D0%B3%D0%BB%D0%B0%D1%81%D0%BD%D1%8B%D0%B9#Russian" title="согласный">согла́сный</a></span><span class="tpos">&#160;<a href="https://ru.wiktionary.org/wiki/%D1%81%D0%BE%D0%B3%D0%BB%D0%B0%D1%81%D0%BD%D1%8B%D0%B9" class="extiw" title="ru:согласный">(ru)</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span> <span class="mention-gloss-paren annotation-paren">(</span><span lang="ru-Latn" class="tr Latn">soglásnyj</span><span class="mention-gloss-paren annotation-paren">)</span>, <span class="Cyrl" lang="ru"><a href="/w/index.php?title=%D1%81%D0%BE%D0%BE%D1%82%D0%B2%D0%B5%D1%82%D1%81%D1%82%D0%B2%D0%B5%D0%BD%D0%BD%D1%8B%D0%B9&amp;action=edit&amp;redlink=1" class="new" title="соответственный (page does not exist)">соотве́тственный</a></span><span class="tpos">&#160;<a href="https://ru.wiktionary.org/wiki/%D1%81%D0%BE%D0%BE%D1%82%D0%B2%D0%B5%D1%82%D1%81%D1%82%D0%B2%D0%B5%D0%BD%D0%BD%D1%8B%D0%B9" class="extiw" title="ru:соответственный">(ru)</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span> <span class="mention-gloss-paren annotation-paren">(</span><span lang="ru-Latn" class="tr Latn">sootvétstvennyj</span><span class="mention-gloss-paren annotation-paren">)</span></li></ul>
+</td></tr></tbody></table></div></div>
+<h3><span class="mw-headline" id="Noun">Noun</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=6" title="Edit section: Noun">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<p><strong class="Latn headword" lang="en">correspondent</strong> (<i>plural</i> <b class="Latn form-of lang-en p-form-of" lang="en"><a href="/wiki/correspondents#English" title="correspondents">correspondents</a></b>)
+</p>
+<ol><li>Someone who or something which <a href="/wiki/correspond" title="correspond">corresponds</a>.</li>
+<li>Someone who communicates with another person, or a publication, by writing.</li>
+<li>A <a href="/wiki/journalist" title="journalist">journalist</a> who sends reports back to a newspaper or radio or television station from a distant or overseas location.</li></ol>
+<h4><span class="mw-headline" id="Hyponyms">Hyponyms</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=7" title="Edit section: Hyponyms">edit</a><span class="mw-editsection-bracket">]</span></span></h4>
+<ul><li><span class="Latn" lang="en"><a href="/wiki/stringer#English" title="stringer">stringer</a></span></li></ul>
+<h4><span class="mw-headline" id="Derived_terms">Derived terms</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=8" title="Edit section: Derived terms">edit</a><span class="mw-editsection-bracket">]</span></span></h4>
+<div class="list-switcher" data-toggle-category="derived terms"><div class="derivedterms term-list ul-column-count" data-column-count="4" style="background-color: #F8F8FF;">
+<ul><li><span class="Latn" lang="en"><a href="/w/index.php?title=correspondential&amp;action=edit&amp;redlink=1" class="new" title="correspondential (page does not exist)">correspondential</a></span></li>
+<li><span class="Latn" lang="en"><a href="/wiki/correspondently#English" title="correspondently">correspondently</a></span></li>
+<li><span class="Latn" lang="en"><a href="/wiki/correspondentship#English" title="correspondentship">correspondentship</a></span></li>
+<li><span class="Latn" lang="en"><a href="/wiki/foreign_correspondent#English" title="foreign correspondent">foreign correspondent</a></span></li></ul></div><div class="list-switcher-element" data-showtext="&#160;show more ▼&#160;" data-hidetext="&#160;show less ▲&#160;" style="display: none;">&#160;</div></div>
+<h4><span class="mw-headline" id="Translations_2">Translations</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=9" title="Edit section: Translations">edit</a><span class="mw-editsection-bracket">]</span></span></h4>
+<div class="NavFrame" id="Translations-one_who_corresponds">
+<div class="NavHead" style="text-align:left;">one who corresponds</div>
+<div class="NavContent">
+<table class="translations" role="presentation" style="width:100%;" data-gloss="one who corresponds">
+
+<tbody><tr>
+<td class="translations-cell" style="background-color:#ffffe0; vertical-align:top; width:48%; text-align:left;">
+<ul><li>Dutch: <span class="Latn" lang="nl"><a href="/wiki/correspondent#Dutch" title="correspondent">correspondent</a></span><span class="tpos">&#160;<a href="https://nl.wiktionary.org/wiki/correspondent" class="extiw" title="nl:correspondent">(nl)</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span></li>
+<li>Hungarian: <span class="Latn" lang="hu"><a href="/wiki/levelez%C5%91#Hungarian" title="levelező">levelező</a></span><span class="tpos">&#160;<a href="https://hu.wiktionary.org/wiki/levelez%C5%91" class="extiw" title="hu:levelező">(hu)</a></span></li>
+<li>Italian: <span class="Latn" lang="it"><a href="/wiki/corrispondente#Italian" title="corrispondente">corrispondente</a></span><span class="tpos">&#160;<a href="https://it.wiktionary.org/wiki/corrispondente" class="extiw" title="it:corrispondente">(it)</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr> or <abbr title="feminine gender">f</abbr></span></li>
+<li>Manx: <span class="Latn" lang="gv"><a href="/wiki/co-screeuder#Manx" title="co-screeuder">co-screeuder</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span></li></ul>
+</td>
+<td style="width:1%;">
+</td>
+<td class="translations-cell" style="background-color:#ffffe0; vertical-align:top; text-align:left; width:48%;">
+<ul><li>Russian: <span class="Cyrl" lang="ru"><a href="/wiki/%D0%BA%D0%BE%D1%80%D1%80%D0%B5%D1%81%D0%BF%D0%BE%D0%BD%D0%B4%D0%B5%D0%BD%D1%82#Russian" title="корреспондент">корреспонде́нт</a></span><span class="tpos">&#160;<a href="https://ru.wiktionary.org/wiki/%D0%BA%D0%BE%D1%80%D1%80%D0%B5%D1%81%D0%BF%D0%BE%D0%BD%D0%B4%D0%B5%D0%BD%D1%82" class="extiw" title="ru:корреспондент">(ru)</a></span> <span class="mention-gloss-paren annotation-paren">(</span><span lang="ru-Latn" class="tr Latn">korrespondént</span><span class="mention-gloss-paren annotation-paren">)</span></li>
+<li>Scottish Gaelic: <span class="Latn" lang="gd"><a href="/wiki/sgr%C3%ACobhaiche#Scottish_Gaelic" title="sgrìobhaiche">sgrìobhaiche</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span></li>
+<li>Volapük: <span class="Latn" lang="vo"><a href="/wiki/spodan#Volapük" title="spodan">spodan</a></span><span class="tpos">&#160;<a href="https://vo.wiktionary.org/wiki/spodan" class="extiw" title="vo:spodan">(vo)</a></span></li></ul>
+</td></tr></tbody></table></div></div>
+<div class="NavFrame" id="Translations-journalist">
+<div class="NavHead" style="text-align:left;">journalist</div>
+<div class="NavContent">
+<table class="translations" role="presentation" style="width:100%;" data-gloss="journalist">
+
+<tbody><tr>
+<td class="translations-cell" style="background-color:#ffffe0; vertical-align:top; width:48%; text-align:left;">
+<ul><li>Catalan: <span class="Latn" lang="ca"><a href="/wiki/corresponsal#Catalan" title="corresponsal">corresponsal</a></span><span class="tpos">&#160;<a href="https://ca.wiktionary.org/wiki/corresponsal" class="extiw" title="ca:corresponsal">(ca)</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr> or <abbr title="feminine gender">f</abbr></span></li>
+<li>Dutch: <span class="Latn" lang="nl"><a href="/wiki/correspondent#Dutch" title="correspondent">correspondent</a></span><span class="tpos">&#160;<a href="https://nl.wiktionary.org/wiki/correspondent" class="extiw" title="nl:correspondent">(nl)</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span></li>
+<li>Finnish: <span class="Latn" lang="fi"><a href="/wiki/kirjeenvaihtaja#Finnish" title="kirjeenvaihtaja">kirjeenvaihtaja</a></span><span class="tpos">&#160;<a href="https://fi.wiktionary.org/wiki/kirjeenvaihtaja" class="extiw" title="fi:kirjeenvaihtaja">(fi)</a></span></li>
+<li>French: <span class="Latn" lang="fr"><a href="/wiki/correspondant#French" title="correspondant">correspondant</a></span><span class="tpos">&#160;<a href="https://fr.wiktionary.org/wiki/correspondant" class="extiw" title="fr:correspondant">(fr)</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span></li>
+<li>Georgian: <span class="Geor" lang="ka"><a href="/w/index.php?title=%E1%83%99%E1%83%9D%E1%83%A0%E1%83%94%E1%83%A1%E1%83%9E%E1%83%9D%E1%83%9C%E1%83%93%E1%83%94%E1%83%9C%E1%83%A2%E1%83%98&amp;action=edit&amp;redlink=1" class="new" title="კორესპონდენტი (page does not exist)">კორესპონდენტი</a></span> <span class="mention-gloss-paren annotation-paren">(</span><span lang="ka-Latn" class="tr Latn">ḳoresṗondenṭi</span><span class="mention-gloss-paren annotation-paren">)</span></li>
+<li>German: <span class="Latn" lang="de"><a href="/wiki/Korrespondent#German" title="Korrespondent">Korrespondent</a></span><span class="tpos">&#160;<a href="https://de.wiktionary.org/wiki/Korrespondent" class="extiw" title="de:Korrespondent">(de)</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span>, <span class="Latn" lang="de"><a href="/wiki/Korrespondentin#German" title="Korrespondentin">Korrespondentin</a></span><span class="tpos">&#160;<a href="https://de.wiktionary.org/wiki/Korrespondentin" class="extiw" title="de:Korrespondentin">(de)</a></span>&#160;<span class="gender"><abbr title="feminine gender">f</abbr></span></li>
+<li>Greek: <span class="Grek" lang="el"><a href="/wiki/%CE%B1%CE%BD%CF%84%CE%B1%CF%80%CE%BF%CE%BA%CF%81%CE%B9%CF%84%CE%AE%CF%82#Greek" title="ανταποκριτής">ανταποκριτής</a></span><span class="tpos">&#160;<a href="https://el.wiktionary.org/wiki/%CE%B1%CE%BD%CF%84%CE%B1%CF%80%CE%BF%CE%BA%CF%81%CE%B9%CF%84%CE%AE%CF%82" class="extiw" title="el:ανταποκριτής">(el)</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span> <span class="mention-gloss-paren annotation-paren">(</span><span lang="el-Latn" class="tr Latn">antapokritís</span><span class="mention-gloss-paren annotation-paren">)</span>, <span class="Grek" lang="el"><a href="/wiki/%CE%B1%CE%BD%CF%84%CE%B1%CF%80%CE%BF%CE%BA%CF%81%CE%AF%CF%84%CF%81%CE%B9%CE%B1#Greek" title="ανταποκρίτρια">ανταποκρίτρια</a></span><span class="tpos">&#160;<a href="https://el.wiktionary.org/wiki/%CE%B1%CE%BD%CF%84%CE%B1%CF%80%CE%BF%CE%BA%CF%81%CE%AF%CF%84%CF%81%CE%B9%CE%B1" class="extiw" title="el:ανταποκρίτρια">(el)</a></span>&#160;<span class="gender"><abbr title="feminine gender">f</abbr></span> <span class="mention-gloss-paren annotation-paren">(</span><span lang="el-Latn" class="tr Latn">antapokrítria</span><span class="mention-gloss-paren annotation-paren">)</span></li>
+<li>Hungarian: <span class="Latn" lang="hu"><a href="/w/index.php?title=tud%C3%B3s%C3%ADt%C3%B3&amp;action=edit&amp;redlink=1" class="new" title="tudósító (page does not exist)">tudósító</a></span><span class="tpos">&#160;<a href="https://hu.wiktionary.org/wiki/tud%C3%B3s%C3%ADt%C3%B3" class="extiw" title="hu:tudósító">(hu)</a></span></li></ul>
+</td>
+<td style="width:1%;">
+</td>
+<td class="translations-cell" style="background-color:#ffffe0; vertical-align:top; text-align:left; width:48%;">
+<ul><li>Italian: <span class="Latn" lang="it"><a href="/wiki/corrispondente#Italian" title="corrispondente">corrispondente</a></span><span class="tpos">&#160;<a href="https://it.wiktionary.org/wiki/corrispondente" class="extiw" title="it:corrispondente">(it)</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr> or <abbr title="feminine gender">f</abbr></span>, <span class="Latn" lang="it"><a href="/wiki/inviato#Italian" title="inviato">inviato</a></span><span class="tpos">&#160;<a href="https://it.wiktionary.org/wiki/inviato" class="extiw" title="it:inviato">(it)</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span>, <span class="Latn" lang="it"><a href="/wiki/inviata#Italian" title="inviata">inviata</a></span>&#160;<span class="gender"><abbr title="feminine gender">f</abbr></span></li>
+<li>Russian: <span class="Cyrl" lang="ru"><a href="/wiki/%D0%BA%D0%BE%D1%80%D1%80%D0%B5%D1%81%D0%BF%D0%BE%D0%BD%D0%B4%D0%B5%D0%BD%D1%82#Russian" title="корреспондент">корреспонде́нт</a></span><span class="tpos">&#160;<a href="https://ru.wiktionary.org/wiki/%D0%BA%D0%BE%D1%80%D1%80%D0%B5%D1%81%D0%BF%D0%BE%D0%BD%D0%B4%D0%B5%D0%BD%D1%82" class="extiw" title="ru:корреспондент">(ru)</a></span> <span class="mention-gloss-paren annotation-paren">(</span><span lang="ru-Latn" class="tr Latn">korrespondént</span><span class="mention-gloss-paren annotation-paren">)</span></li>
+<li>Scottish Gaelic: <span class="Latn" lang="gd"><a href="/wiki/sgr%C3%ACobhaiche#Scottish_Gaelic" title="sgrìobhaiche">sgrìobhaiche</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span></li>
+<li>Sorbian:
+<dl><dd>Lower Sorbian: <span class="Latn" lang="dsb"><a href="/wiki/korespondent#Lower_Sorbian" title="korespondent">korespondent</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span>, <span class="Latn" lang="dsb"><a href="/wiki/korespondentka#Lower_Sorbian" title="korespondentka">korespondentka</a></span>&#160;<span class="gender"><abbr title="feminine gender">f</abbr></span></dd></dl></li>
+<li>Spanish: <span class="Latn" lang="es"><a href="/wiki/corresponsal#Spanish" title="corresponsal">corresponsal</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr> or <abbr title="feminine gender">f</abbr></span></li>
+<li>Swedish: <span class="Latn" lang="sv"><a href="/wiki/korrespondent#Swedish" title="korrespondent">korrespondent</a></span><span class="tpos">&#160;<a href="https://sv.wiktionary.org/wiki/korrespondent" class="extiw" title="sv:korrespondent">(sv)</a></span>&#160;<span class="gender"><abbr title="common gender">c</abbr></span></li></ul>
+</td></tr></tbody></table></div></div>
+<div class="checktrans">
+<dl><dd><i>The translations below need to be checked and inserted above into the appropriate translation tables, removing any numbers. Numbers do not necessarily match those in definitions. See instructions at <a href="/wiki/Wiktionary:Entry_layout#Translations" title="Wiktionary:Entry layout">Wiktionary:Entry layout §&#160;Translations</a>.</i></dd></dl>
+</div>
+<div class="NavFrame">
+<div class="NavHead" style="text-align:left;">Translations to be checked</div>
+<div class="NavContent">
+<table class="translations" role="presentation" style="width:100%;" data-gloss="Translations to be checked">
+
+<tbody><tr>
+<td class="translations-cell" style="background-color:#ffffe0; vertical-align:top; width:48%; text-align:left;">
+<ul><li>Bulgarian: <span class="ttbc"><sup class="ttbc">(please <a href="/wiki/Wiktionary:Translations#Translations_to_be_checked" title="Wiktionary:Translations">verify</a>)</sup> <span class="Cyrl" lang="bg"><a href="/w/index.php?title=%D0%BA%D0%BE%D1%80%D0%B5%D1%81%D0%BF%D0%BE%D0%BD%D0%B4%D0%B5%D0%BD%D1%82&amp;action=edit&amp;redlink=1" class="new" title="кореспондент (page does not exist)">кореспондент</a></span><span class="tpos">&#160;<a href="https://bg.wiktionary.org/wiki/%D0%BA%D0%BE%D1%80%D0%B5%D1%81%D0%BF%D0%BE%D0%BD%D0%B4%D0%B5%D0%BD%D1%82" class="extiw" title="bg:кореспондент">(bg)</a></span> <span class="mention-gloss-paren annotation-paren">(</span><span lang="bg-Latn" class="tr Latn">korespondent</span><span class="mention-gloss-paren annotation-paren">)</span></span>, <span class="ttbc"><sup class="ttbc">(please <a href="/wiki/Wiktionary:Translations#Translations_to_be_checked" title="Wiktionary:Translations">verify</a>)</sup> <span class="Cyrl" lang="bg"><a href="/wiki/%D0%B4%D0%BE%D0%BF%D0%B8%D1%81%D0%BD%D0%B8%D0%BA#Bulgarian" title="дописник">дописник</a></span><span class="tpos">&#160;<a href="https://bg.wiktionary.org/wiki/%D0%B4%D0%BE%D0%BF%D0%B8%D1%81%D0%BD%D0%B8%D0%BA" class="extiw" title="bg:дописник">(bg)</a></span> <span class="mention-gloss-paren annotation-paren">(</span><span lang="bg-Latn" class="tr Latn">dopisnik</span><span class="mention-gloss-paren annotation-paren">)</span></span></li>
+<li>Manx: <span class="ttbc"><sup class="ttbc">(please <a href="/wiki/Wiktionary:Translations#Translations_to_be_checked" title="Wiktionary:Translations">verify</a>)</sup> <span class="Latn" lang="gv"><a href="/wiki/co-reggyrtagh#Manx" title="co-reggyrtagh">co-reggyrtagh</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span></span></li></ul>
+</td>
+<td style="width:1%;">
+</td>
+<td class="translations-cell" style="background-color:#ffffe0; vertical-align:top; text-align:left; width:48%;">
+<ul><li>Norman: <span class="ttbc"><sup class="ttbc">(please <a href="/wiki/Wiktionary:Translations#Translations_to_be_checked" title="Wiktionary:Translations">verify</a>)</sup> <span class="Latn" lang="nrf"><a href="/wiki/correspondent#Norman" title="correspondent">correspondent</a></span>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span></span> <span class="ib-brac qualifier-brac">(</span><span class="ib-content qualifier-content">Jersey</span><span class="ib-brac qualifier-brac">)</span></li></ul>
+</td></tr></tbody></table></div></div>
+<h3><span class="mw-headline" id="See_also">See also</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=10" title="Edit section: See also">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<ul><li><span class="Latn" lang="en"><a href="/wiki/corespondent#English" title="corespondent">corespondent</a></span></li>
+<li><a href="https://en.wikipedia.org/wiki/Correspondent" class="extiw" title="w:Correspondent">Correspondent</a> in Wikipedia</li></ul>
+<h3><span class="mw-headline" id="References">References</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=11" title="Edit section: References">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<ul><li><a rel="nofollow" class="external text" href="http://www.websters1913.com/words/Correspondent">correspondent</a> in <i><a href="/wiki/Wiktionary:Webster%27s_Dictionary,_1913" title="Wiktionary:Webster&#39;s Dictionary, 1913">Webster’s Revised Unabridged Dictionary</a></i>, G. &amp; C. Merriam, 1913.</li></ul>
+<hr />
+<h2><span class="mw-headline" id="Dutch">Dutch</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=12" title="Edit section: Dutch">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<h3><span class="mw-headline" id="Alternative_forms">Alternative forms</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=13" title="Edit section: Alternative forms">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<ul><li><span class="Latn" lang="nl"><a href="/wiki/korrespondent#Dutch" title="korrespondent">korrespondent</a></span> (<i>before 1996</i>)</li></ul>
+<h3><span class="mw-headline" id="Etymology_2">Etymology</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=14" title="Edit section: Etymology">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<p>Borrowed from <span class="etyl"><a href="https://en.wikipedia.org/wiki/Middle_French" class="extiw" title="w:Middle French">Middle French</a></span> <i class="Latn mention" lang="frm"><a href="/wiki/correspondant#Middle_French" title="correspondant">correspondant</a></i>, <i class="Latn mention" lang="frm"><a href="/wiki/correspondent#Middle_French" title="correspondent">correspondent</a></i>, from <span class="etyl"><a href="https://en.wikipedia.org/wiki/Latin" class="extiw" title="w:Latin">Latin</a></span> <i class="Latn mention" lang="la"><a href="/wiki/correspondens#Latin" title="correspondens">correspondens</a></i>.
+</p>
+<h3><span class="mw-headline" id="Pronunciation_2">Pronunciation</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=15" title="Edit section: Pronunciation">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<ul><li><a href="/wiki/Wiktionary:International_Phonetic_Alphabet" title="Wiktionary:International Phonetic Alphabet">IPA</a><sup>(<a href="/wiki/Appendix:Dutch_pronunciation" title="Appendix:Dutch pronunciation">key</a>)</sup>:&#32;<span class="IPA">/ˌkɔ.rɛs.pɔnˈdɛnt/</span>, <span class="IPA">/ˌkɔ.rə.spɔnˈdɛnt/</span></li>
+<li><link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r50165410"/><table class="audiotable" style="vertical-align: bottom; display:inline-block; list-style:none;line-height: 1em; border-collapse:collapse;"><tbody><tr><td class="unicode audiolink" style="padding-right:5px; padding-left: 0;">Audio</td><td class="audiofile"><div class="mediaContainer" style="width:175px"><audio id="mwe_player_1" controls="" preload="none" style="width:175px" class="kskin" data-durationhint="1.3" data-startoffset="0" data-mwtitle="Nl-correspondent.ogg" data-mwprovider="wikimediacommons"><source src="//upload.wikimedia.org/wikipedia/commons/1/1b/Nl-correspondent.ogg" type="audio/ogg; codecs=&quot;vorbis&quot;" data-title="Original Ogg file (100 kbps)" data-shorttitle="Ogg source" data-width="0" data-height="0" data-bandwidth="99717" /><source src="//upload.wikimedia.org/wikipedia/commons/transcoded/1/1b/Nl-correspondent.ogg/Nl-correspondent.ogg.mp3" type="audio/mpeg" data-title="MP3" data-shorttitle="MP3" data-transcodekey="mp3" data-width="0" data-height="0" data-bandwidth="148528" /></audio></div></td><td class="audiometa" style="font-size: 80%;">(<a href="/wiki/File:Nl-correspondent.ogg" title="File:Nl-correspondent.ogg">file</a>)</td></tr></tbody></table></li>
+<li>Hyphenation: <span class="Latn" lang="nl">cor‧res‧pon‧dent</span></li>
+<li>Rhymes: <a href="/wiki/Rhymes:Dutch/%C9%9Bnt" title="Rhymes:Dutch/ɛnt"><span class="IPA">-ɛnt</span></a></li></ul>
+<h3><span class="mw-headline" id="Noun_2">Noun</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=16" title="Edit section: Noun">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<p><strong class="Latn headword" lang="nl">correspondent</strong>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span> (<i>plural</i> <b class="Latn form-of lang-nl p-form-of" lang="nl"><a href="/wiki/correspondenten#Dutch" title="correspondenten">correspondenten</a></b>, <i><a href="/wiki/Appendix:Glossary#diminutive" title="Appendix:Glossary">diminutive</a></i> <b class="Latn form-of lang-nl diminutive-form-of" lang="nl"><a href="/wiki/correspondentje#Dutch" title="correspondentje">correspondentje</a></b>&#160;<span class="gender"><abbr title="neuter gender">n</abbr></span>, <i>feminine</i> <b class="Latn" lang="nl"><a href="/wiki/correspondente#Dutch" title="correspondente">correspondente</a></b>)
+</p>
+<ol><li>A <a href="#English">correspondent</a>, in particular a <a href="/wiki/reporter" title="reporter">reporter</a>.</li></ol>
+<h4><span class="mw-headline" id="Related_terms">Related terms</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=17" title="Edit section: Related terms">edit</a><span class="mw-editsection-bracket">]</span></span></h4>
+<ul><li><span class="Latn" lang="nl"><a href="/wiki/correspondentie#Dutch" title="correspondentie">correspondentie</a></span></li>
+<li><span class="Latn" lang="nl"><a href="/wiki/corresponderen#Dutch" title="corresponderen">corresponderen</a></span></li></ul>
+<hr />
+<h2><span class="mw-headline" id="French">French</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=18" title="Edit section: French">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<h3><span class="mw-headline" id="Pronunciation_3">Pronunciation</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=19" title="Edit section: Pronunciation">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<ul><li><a href="/wiki/Wiktionary:International_Phonetic_Alphabet" title="Wiktionary:International Phonetic Alphabet">IPA</a><sup>(<a href="/wiki/Appendix:French_pronunciation" title="Appendix:French pronunciation">key</a>)</sup>:&#32;<span class="IPA">/kɔ.ʁɛs.pɔ̃d/</span></li></ul>
+<h3><span class="mw-headline" id="Verb">Verb</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=20" title="Edit section: Verb">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<p><strong class="Latn headword" lang="fr">correspondent</strong>
+</p>
+<ol><li><span class="form-of-definition use-with-mention"><a href="/wiki/Appendix:Glossary#third_person" title="Appendix:Glossary">third-person</a> <a href="/wiki/Appendix:Glossary#plural_number" title="Appendix:Glossary">plural</a> <a href="/wiki/Appendix:Glossary#present_tense" title="Appendix:Glossary">present</a> <a href="/wiki/Appendix:Glossary#indicative_mood" title="Appendix:Glossary">indicative</a> of <span class="form-of-definition-link"><i class="Latn mention" lang="fr"><a href="/wiki/correspondre#French" title="correspondre">correspondre</a></i></span></span></li>
+<li><span class="form-of-definition use-with-mention"><a href="/wiki/Appendix:Glossary#third_person" title="Appendix:Glossary">third-person</a> <a href="/wiki/Appendix:Glossary#plural_number" title="Appendix:Glossary">plural</a> <a href="/wiki/Appendix:Glossary#present_tense" title="Appendix:Glossary">present</a> <a href="/wiki/Appendix:Glossary#subjunctive_mood" title="Appendix:Glossary">subjunctive</a> of <span class="form-of-definition-link"><i class="Latn mention" lang="fr"><a href="/wiki/correspondre#French" title="correspondre">correspondre</a></i></span></span></li></ol>
+<hr />
+<h2><span class="mw-headline" id="Latin">Latin</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=21" title="Edit section: Latin">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<h3><span class="mw-headline" id="Verb_2">Verb</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=22" title="Edit section: Verb">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<p><strong class="Latn headword" lang="la">correspondent</strong>
+</p>
+<ol><li><span class="form-of-definition use-with-mention"><a href="/wiki/Appendix:Glossary#third_person" title="Appendix:Glossary">third-person</a> <a href="/wiki/Appendix:Glossary#plural_number" title="Appendix:Glossary">plural</a> <a href="/wiki/Appendix:Glossary#present_tense" title="Appendix:Glossary">present</a> <a href="/wiki/Appendix:Glossary#active_voice" title="Appendix:Glossary">active</a> <a href="/wiki/Appendix:Glossary#indicative_mood" title="Appendix:Glossary">indicative</a> of <span class="form-of-definition-link"><i class="Latn mention" lang="la"><a href="/wiki/correspondeo#Latin" title="correspondeo">correspondeō</a></i></span></span></li></ol>
+<hr />
+<h2><span class="mw-headline" id="Norman">Norman</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=23" title="Edit section: Norman">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
+<h3><span class="mw-headline" id="Etymology_3">Etymology</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=24" title="Edit section: Etymology">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<p><span class="maintenance-line" style="color: #777777;">(This <a href="/wiki/Wiktionary:Etymology" title="Wiktionary:Etymology">etymology</a> is missing or incomplete. Please add to it, or discuss it at the <a href="/wiki/Wiktionary:Etymology_scriptorium" title="Wiktionary:Etymology scriptorium">Etymology scriptorium</a>.)</span>
+</p>
+<h3><span class="mw-headline" id="Noun_3">Noun</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=correspondent&amp;action=edit&amp;section=25" title="Edit section: Noun">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+<p><strong class="Latn headword" lang="nrf">correspondent</strong>&#160;<span class="gender"><abbr title="masculine gender">m</abbr></span> (<i>plural</i> <b class="Latn form-of lang-nrf p-form-of" lang="nrf"><a href="/wiki/correspondents#Norman" title="correspondents">correspondents</a></b>, <i>feminine</i> <b class="Latn" lang="nrf"><a href="/wiki/correspondente#Norman" title="correspondente">correspondente</a></b>)
+</p>
+<ol><li><span class="ib-brac">(</span><span class="ib-content"><a href="https://en.wikipedia.org/wiki/Jersey" class="extiw" title="w:Jersey">Jersey</a></span><span class="ib-brac">)</span> <a href="#English">correspondent</a></li></ol>
+<!--
+NewPP limit report
+Parsed by mw1294
+Cached time: 20201113204328
+Cache expiry: 86400
+Dynamic content: true
+Complications: []
+CPU time usage: 0.844 seconds
+Real time usage: 1.132 seconds
+Preprocessor visited node count: 16217/1000000
+Post‐expand include size: 63301/2097152 bytes
+Template argument size: 15234/2097152 bytes
+Highest expansion depth: 28/40
+Expensive parser function count: 9/500
+Unstrip recursion depth: 0/20
+Unstrip post‐expand size: 330/5000000 bytes
+Lua time usage: 0.409/10.000 seconds
+Lua memory usage: 15.41 MB/50 MB
+Number of Wikibase entities loaded: 0/400
+-->
+<!--
+Transclusion expansion time report (%,ms,calls,template)
+100.00% 1009.255      1 -total
+ 21.26%  214.527     14 Template:check_deprecated_lang_param_usage
+ 20.83%  210.190     14 Template:deprecated_code
+ 20.21%  203.939     23 Template:t+
+ 17.20%  173.604     37 Template:redlink_category
+ 12.61%  127.264      4 Template:der
+  6.57%   66.314      2 Template:lb
+  6.49%   65.523      8 Template:t
+  6.37%   64.301      3 Template:IPA
+  5.41%   54.622      3 Template:inflection_of
+-->
+
+<!-- Saved in parser cache with key enwiktionary:pcache:idhash:229376-0!canonical and timestamp 20201113204328 and revision id 61052028. Serialized with PHP.
+ -->
+</div><noscript><img src="//en.wiktionary.org/wiki/Special:CentralAutoLogin/start?type=1x1" alt="" title="" width="1" height="1" style="border: none; position: absolute;" /></noscript>
+<div class="printfooter">Retrieved from "<a dir="ltr" href="https://en.wiktionary.org/w/index.php?title=correspondent&amp;oldid=61052028">https://en.wiktionary.org/w/index.php?title=correspondent&amp;oldid=61052028</a>"</div></div>
+		<div id="catlinks" class="catlinks" data-mw="interface"><div id="mw-normal-catlinks" class="mw-normal-catlinks"><a href="/wiki/Special:Categories" title="Special:Categories">Categories</a>: <ul><li><a href="/wiki/Category:English_terms_derived_from_Latin" title="Category:English terms derived from Latin">English terms derived from Latin</a></li><li><a href="/wiki/Category:English_terms_derived_from_Middle_French" title="Category:English terms derived from Middle French">English terms derived from Middle French</a></li><li><a href="/wiki/Category:English_terms_derived_from_Medieval_Latin" title="Category:English terms derived from Medieval Latin">English terms derived from Medieval Latin</a></li><li><a href="/wiki/Category:English_4-syllable_words" title="Category:English 4-syllable words">English 4-syllable words</a></li><li><a href="/wiki/Category:English_terms_with_IPA_pronunciation" title="Category:English terms with IPA pronunciation">English terms with IPA pronunciation</a></li><li><a href="/wiki/Category:English_terms_with_audio_links" title="Category:English terms with audio links">English terms with audio links</a></li><li><a href="/wiki/Category:English_lemmas" title="Category:English lemmas">English lemmas</a></li><li><a href="/wiki/Category:English_adjectives" title="Category:English adjectives">English adjectives</a></li><li><a href="/wiki/Category:English_terms_with_quotations" title="Category:English terms with quotations">English terms with quotations</a></li><li><a href="/wiki/Category:English_nouns" title="Category:English nouns">English nouns</a></li><li><a href="/wiki/Category:English_countable_nouns" title="Category:English countable nouns">English countable nouns</a></li><li><a href="/wiki/Category:en:People" title="Category:en:People">en:People</a></li><li><a href="/wiki/Category:Dutch_terms_borrowed_from_Middle_French" title="Category:Dutch terms borrowed from Middle French">Dutch terms borrowed from Middle French</a></li><li><a href="/wiki/Category:Dutch_terms_derived_from_Middle_French" title="Category:Dutch terms derived from Middle French">Dutch terms derived from Middle French</a></li><li><a href="/wiki/Category:Dutch_terms_derived_from_Latin" title="Category:Dutch terms derived from Latin">Dutch terms derived from Latin</a></li><li><a href="/wiki/Category:Dutch_terms_with_IPA_pronunciation" title="Category:Dutch terms with IPA pronunciation">Dutch terms with IPA pronunciation</a></li><li><a href="/wiki/Category:Dutch_terms_with_audio_links" title="Category:Dutch terms with audio links">Dutch terms with audio links</a></li><li><a href="/wiki/Category:Dutch_lemmas" title="Category:Dutch lemmas">Dutch lemmas</a></li><li><a href="/wiki/Category:Dutch_nouns" title="Category:Dutch nouns">Dutch nouns</a></li><li><a href="/wiki/Category:Dutch_nouns_with_plural_in_-en" title="Category:Dutch nouns with plural in -en">Dutch nouns with plural in -en</a></li><li><a href="/wiki/Category:Dutch_masculine_nouns" title="Category:Dutch masculine nouns">Dutch masculine nouns</a></li><li><a href="/wiki/Category:French_3-syllable_words" title="Category:French 3-syllable words">French 3-syllable words</a></li><li><a href="/wiki/Category:French_terms_with_IPA_pronunciation" title="Category:French terms with IPA pronunciation">French terms with IPA pronunciation</a></li><li><a href="/wiki/Category:French_non-lemma_forms" title="Category:French non-lemma forms">French non-lemma forms</a></li><li><a href="/wiki/Category:French_verb_forms" title="Category:French verb forms">French verb forms</a></li><li><a href="/wiki/Category:Latin_non-lemma_forms" title="Category:Latin non-lemma forms">Latin non-lemma forms</a></li><li><a href="/wiki/Category:Latin_verb_forms" title="Category:Latin verb forms">Latin verb forms</a></li><li><a href="/wiki/Category:Norman_lemmas" title="Category:Norman lemmas">Norman lemmas</a></li><li><a href="/wiki/Category:Norman_nouns" title="Category:Norman nouns">Norman nouns</a></li><li><a href="/wiki/Category:Norman_masculine_nouns" title="Category:Norman masculine nouns">Norman masculine nouns</a></li><li><a href="/wiki/Category:Jersey_Norman" title="Category:Jersey Norman">Jersey Norman</a></li></ul></div><div id="mw-hidden-catlinks" class="mw-hidden-catlinks mw-hidden-cats-hidden">Hidden categories: <ul><li><a href="/wiki/Category:Tea_room" title="Category:Tea room">Tea room</a></li><li><a href="/wiki/Category:Requests_for_attention_concerning_English" title="Category:Requests for attention concerning English">Requests for attention concerning English</a></li><li><a href="/wiki/Category:Russian_redlinks" title="Category:Russian redlinks">Russian redlinks</a></li><li><a href="/wiki/Category:Russian_redlinks/t%2B" title="Category:Russian redlinks/t+">Russian redlinks/t+</a></li><li><a href="/wiki/Category:Requests_for_review_of_Bulgarian_translations" title="Category:Requests for review of Bulgarian translations">Requests for review of Bulgarian translations</a></li><li><a href="/wiki/Category:Requests_for_review_of_Manx_translations" title="Category:Requests for review of Manx translations">Requests for review of Manx translations</a></li><li><a href="/wiki/Category:Requests_for_review_of_Norman_translations" title="Category:Requests for review of Norman translations">Requests for review of Norman translations</a></li><li><a href="/wiki/Category:Requests_for_etymologies_in_Norman_entries" title="Category:Requests for etymologies in Norman entries">Requests for etymologies in Norman entries</a></li></ul></div></div>
+	</div>
+</div>
+
+<div id="mw-navigation">
+	<h2>Navigation menu</h2>
+	<div id="mw-head">
+		<!-- Please do not use role attribute as CSS selector, it is deprecated. -->
+<nav id="p-personal" class="mw-portlet mw-portlet-personal vector-menu" aria-labelledby="p-personal-label" role="navigation"
+	 >
+	<h3 id="p-personal-label">
+		<span>Personal tools</span>
+	</h3>
+	<div class="vector-menu-content">
+		<ul class="vector-menu-content-list"><li id="pt-anonuserpage">Not logged in</li><li id="pt-anontalk"><a href="/wiki/Special:MyTalk" title="Discussion about edits from this IP address [n]" accesskey="n">Talk</a></li><li id="pt-anoncontribs"><a href="/wiki/Special:MyContributions" title="A list of edits made from this IP address [y]" accesskey="y">Contributions</a></li><li id="pt-createaccount"><a href="/w/index.php?title=Special:CreateAccount&amp;returnto=correspondent" title="You are encouraged to create an account and log in; however, it is not mandatory">Create account</a></li><li id="pt-login"><a href="/w/index.php?title=Special:UserLogin&amp;returnto=correspondent" title="You are encouraged to log in; however, it is not mandatory [o]" accesskey="o">Log in</a></li></ul>
+
+	</div>
+</nav>
+
+		<div id="left-navigation">
+			<!-- Please do not use role attribute as CSS selector, it is deprecated. -->
+<nav id="p-namespaces" class="mw-portlet mw-portlet-namespaces vector-menu vector-menu-tabs" aria-labelledby="p-namespaces-label" role="navigation"
+	 >
+	<h3 id="p-namespaces-label">
+		<span>Namespaces</span>
+	</h3>
+	<div class="vector-menu-content">
+		<ul class="vector-menu-content-list"><li id="ca-nstab-main" class="selected"><a href="/wiki/correspondent" title="View the content page [c]" accesskey="c">Entry</a></li><li id="ca-talk" class="new"><a href="/w/index.php?title=Talk:correspondent&amp;action=edit&amp;redlink=1" rel="discussion" title="Discussion about the content page (page does not exist) [t]" accesskey="t">Discussion</a></li></ul>
+
+	</div>
+</nav>
+
+			<!-- Please do not use role attribute as CSS selector, it is deprecated. -->
+<nav id="p-variants" class="mw-portlet mw-portlet-variants emptyPortlet vector-menu vector-menu-dropdown" aria-labelledby="p-variants-label" role="navigation"
+	 >
+	<input type="checkbox" class="vector-menu-checkbox" aria-labelledby="p-variants-label" />
+	<h3 id="p-variants-label">
+		<span>Variants</span>
+	</h3>
+	<div class="vector-menu-content">
+		<ul class="vector-menu-content-list"></ul>
+
+	</div>
+</nav>
+
+		</div>
+		<div id="right-navigation">
+			<!-- Please do not use role attribute as CSS selector, it is deprecated. -->
+<nav id="p-views" class="mw-portlet mw-portlet-views vector-menu vector-menu-tabs" aria-labelledby="p-views-label" role="navigation"
+	 >
+	<h3 id="p-views-label">
+		<span>Views</span>
+	</h3>
+	<div class="vector-menu-content">
+		<ul class="vector-menu-content-list"><li id="ca-view" class="selected"><a href="/wiki/correspondent">Read</a></li><li id="ca-edit"><a href="/w/index.php?title=correspondent&amp;action=edit" title="Edit this page [e]" accesskey="e">Edit</a></li><li id="ca-history"><a href="/w/index.php?title=correspondent&amp;action=history" title="Past revisions of this page [h]" accesskey="h">History</a></li></ul>
+
+	</div>
+</nav>
+
+			<!-- Please do not use role attribute as CSS selector, it is deprecated. -->
+<nav id="p-cactions" class="mw-portlet mw-portlet-cactions emptyPortlet vector-menu vector-menu-dropdown" aria-labelledby="p-cactions-label" role="navigation"
+	 >
+	<input type="checkbox" class="vector-menu-checkbox" aria-labelledby="p-cactions-label" />
+	<h3 id="p-cactions-label">
+		<span>More</span>
+	</h3>
+	<div class="vector-menu-content">
+		<ul class="vector-menu-content-list"></ul>
+
+	</div>
+</nav>
+
+			<div id="p-search" role="search">
+	<h3 >
+		<label for="searchInput">Search</label>
+	</h3>
+	<form action="/w/index.php" id="searchform">
+		<div id="simpleSearch" data-search-loc="header-navigation">
+			<input type="search" name="search" placeholder="Search Wiktionary" autocapitalize="none" title="Search Wiktionary [f]" accesskey="f" id="searchInput"/>
+			<input type="hidden" name="title" value="Special:Search">
+			<input type="submit" name="fulltext" value="Search" title="Search the pages for this text" id="mw-searchButton" class="searchButton mw-fallbackSearchButton"/>
+			<input type="submit" name="go" value="Go" title="Go to a page with this exact name if it exists" id="searchButton" class="searchButton"/>
+		</div>
+	</form>
+</div>
+
+		</div>
+	</div>
+
+<div id="mw-panel">
+	<div id="p-logo" role="banner">
+		<a  title="Visit the main page" class="mw-wiki-logo" href="/wiki/Wiktionary:Main_Page"></a>
+	</div>
+	<!-- Please do not use role attribute as CSS selector, it is deprecated. -->
+<nav id="p-navigation" class="mw-portlet mw-portlet-navigation vector-menu vector-menu-portal portal portal-first" aria-labelledby="p-navigation-label" role="navigation"
+	 >
+	<h3 id="p-navigation-label">
+		<span>Navigation</span>
+	</h3>
+	<div class="vector-menu-content">
+		<ul class="vector-menu-content-list"><li id="n-mainpage-text"><a href="/wiki/Wiktionary:Main_Page">Main Page</a></li><li id="n-portal"><a href="/wiki/Wiktionary:Community_portal" title="About the project, what you can do, where to find things">Community portal</a></li><li id="n-wiktprefs"><a href="/wiki/Wiktionary:Per-browser_preferences">Preferences</a></li><li id="n-requestedarticles"><a href="/wiki/Wiktionary:Requested_entries">Requested entries</a></li><li id="n-recentchanges"><a href="/wiki/Special:RecentChanges" title="A list of recent changes in the wiki [r]" accesskey="r">Recent changes</a></li><li id="n-randompage"><a href="/wiki/Special:Random" title="Load a random page [x]" accesskey="x">Random entry</a></li><li id="n-help"><a href="https://en.wiktionary.org/wiki/Help:Contents" title="The place to find out">Help</a></li><li id="n-Glossary"><a href="/wiki/Appendix:Glossary">Glossary</a></li><li id="n-sitesupport"><a href="//donate.wikimedia.org/wiki/Special:FundraiserRedirector?utm_source=donate&amp;utm_medium=sidebar&amp;utm_campaign=C13_en.wiktionary.org&amp;uselang=en" title="Support us">Donations</a></li><li id="n-contact"><a href="/wiki/Wiktionary:Contact_us">Contact us</a></li></ul>
+
+	</div>
+</nav>
+
+	<!-- Please do not use role attribute as CSS selector, it is deprecated. -->
+<nav id="p-tb" class="mw-portlet mw-portlet-tb vector-menu vector-menu-portal portal" aria-labelledby="p-tb-label" role="navigation"
+	 >
+	<h3 id="p-tb-label">
+		<span>Tools</span>
+	</h3>
+	<div class="vector-menu-content">
+		<ul class="vector-menu-content-list"><li id="t-whatlinkshere"><a href="/wiki/Special:WhatLinksHere/correspondent" title="A list of all wiki pages that link here [j]" accesskey="j">What links here</a></li><li id="t-recentchangeslinked"><a href="/wiki/Special:RecentChangesLinked/correspondent" rel="nofollow" title="Recent changes in pages linked from this page [k]" accesskey="k">Related changes</a></li><li id="t-upload"><a href="//commons.wikimedia.org/wiki/Special:UploadWizard?uselang=en" title="Upload files [u]" accesskey="u">Upload file</a></li><li id="t-specialpages"><a href="/wiki/Special:SpecialPages" title="A list of all special pages [q]" accesskey="q">Special pages</a></li><li id="t-permalink"><a href="/w/index.php?title=correspondent&amp;oldid=61052028" title="Permanent link to this revision of the page">Permanent link</a></li><li id="t-info"><a href="/w/index.php?title=correspondent&amp;action=info" title="More information about this page">Page information</a></li><li id="t-cite"><a href="/w/index.php?title=Special:CiteThisPage&amp;page=correspondent&amp;id=61052028&amp;wpFormIdentifier=titleform" title="Information on how to cite this page">Cite this page</a></li></ul>
+
+	</div>
+</nav>
+<!-- Please do not use role attribute as CSS selector, it is deprecated. -->
+<nav id="p-coll-print_export" class="mw-portlet mw-portlet-coll-print_export vector-menu vector-menu-portal portal" aria-labelledby="p-coll-print_export-label" role="navigation"
+	 >
+	<h3 id="p-coll-print_export-label">
+		<span>Print/export</span>
+	</h3>
+	<div class="vector-menu-content">
+		<ul class="vector-menu-content-list"><li id="coll-create_a_book"><a href="/w/index.php?title=Special:Book&amp;bookcmd=book_creator&amp;referer=correspondent">Create a book</a></li><li id="coll-download-as-rl"><a href="/w/index.php?title=Special:DownloadAsPdf&amp;page=correspondent&amp;action=show-download-screen">Download as PDF</a></li><li id="t-print"><a href="/w/index.php?title=correspondent&amp;printable=yes" title="Printable version of this page [p]" accesskey="p">Printable version</a></li></ul>
+
+	</div>
+</nav>
+
+	<!-- Please do not use role attribute as CSS selector, it is deprecated. -->
+<nav id="p-lang" class="mw-portlet mw-portlet-lang vector-menu vector-menu-portal portal" aria-labelledby="p-lang-label" role="navigation"
+	 >
+	<h3 id="p-lang-label">
+		<span>In other languages</span>
+	</h3>
+	<div class="vector-menu-content">
+		<ul class="vector-menu-content-list"><li class="interlanguage-link interwiki-ar"><a href="https://ar.wiktionary.org/wiki/correspondent" title="correspondent – Arabic" lang="ar" hreflang="ar" class="interlanguage-link-target">العربية</a></li><li class="interlanguage-link interwiki-ca"><a href="https://ca.wiktionary.org/wiki/correspondent" title="correspondent – Catalan" lang="ca" hreflang="ca" class="interlanguage-link-target">Català</a></li><li class="interlanguage-link interwiki-cs"><a href="https://cs.wiktionary.org/wiki/correspondent" title="correspondent – Czech" lang="cs" hreflang="cs" class="interlanguage-link-target">Čeština</a></li><li class="interlanguage-link interwiki-et"><a href="https://et.wiktionary.org/wiki/correspondent" title="correspondent – Estonian" lang="et" hreflang="et" class="interlanguage-link-target">Eesti</a></li><li class="interlanguage-link interwiki-el"><a href="https://el.wiktionary.org/wiki/correspondent" title="correspondent – Greek" lang="el" hreflang="el" class="interlanguage-link-target">Ελληνικά</a></li><li class="interlanguage-link interwiki-eo"><a href="https://eo.wiktionary.org/wiki/correspondent" title="correspondent – Esperanto" lang="eo" hreflang="eo" class="interlanguage-link-target">Esperanto</a></li><li class="interlanguage-link interwiki-fr"><a href="https://fr.wiktionary.org/wiki/correspondent" title="correspondent – French" lang="fr" hreflang="fr" class="interlanguage-link-target">Français</a></li><li class="interlanguage-link interwiki-ga"><a href="https://ga.wiktionary.org/wiki/correspondent" title="correspondent – Irish" lang="ga" hreflang="ga" class="interlanguage-link-target">Gaeilge</a></li><li class="interlanguage-link interwiki-ko"><a href="https://ko.wiktionary.org/wiki/correspondent" title="correspondent – Korean" lang="ko" hreflang="ko" class="interlanguage-link-target">한국어</a></li><li class="interlanguage-link interwiki-hy"><a href="https://hy.wiktionary.org/wiki/correspondent" title="correspondent – Armenian" lang="hy" hreflang="hy" class="interlanguage-link-target">Հայերեն</a></li><li class="interlanguage-link interwiki-io"><a href="https://io.wiktionary.org/wiki/correspondent" title="correspondent – Ido" lang="io" hreflang="io" class="interlanguage-link-target">Ido</a></li><li class="interlanguage-link interwiki-it"><a href="https://it.wiktionary.org/wiki/correspondent" title="correspondent – Italian" lang="it" hreflang="it" class="interlanguage-link-target">Italiano</a></li><li class="interlanguage-link interwiki-kn"><a href="https://kn.wiktionary.org/wiki/correspondent" title="correspondent – Kannada" lang="kn" hreflang="kn" class="interlanguage-link-target">ಕನ್ನಡ</a></li><li class="interlanguage-link interwiki-hu"><a href="https://hu.wiktionary.org/wiki/correspondent" title="correspondent – Hungarian" lang="hu" hreflang="hu" class="interlanguage-link-target">Magyar</a></li><li class="interlanguage-link interwiki-mg"><a href="https://mg.wiktionary.org/wiki/correspondent" title="correspondent – Malagasy" lang="mg" hreflang="mg" class="interlanguage-link-target">Malagasy</a></li><li class="interlanguage-link interwiki-ml"><a href="https://ml.wiktionary.org/wiki/correspondent" title="correspondent – Malayalam" lang="ml" hreflang="ml" class="interlanguage-link-target">മലയാളം</a></li><li class="interlanguage-link interwiki-nl"><a href="https://nl.wiktionary.org/wiki/correspondent" title="correspondent – Dutch" lang="nl" hreflang="nl" class="interlanguage-link-target">Nederlands</a></li><li class="interlanguage-link interwiki-ja"><a href="https://ja.wiktionary.org/wiki/correspondent" title="correspondent – Japanese" lang="ja" hreflang="ja" class="interlanguage-link-target">日本語</a></li><li class="interlanguage-link interwiki-pl"><a href="https://pl.wiktionary.org/wiki/correspondent" title="correspondent – Polish" lang="pl" hreflang="pl" class="interlanguage-link-target">Polski</a></li><li class="interlanguage-link interwiki-ru"><a href="https://ru.wiktionary.org/wiki/correspondent" title="correspondent – Russian" lang="ru" hreflang="ru" class="interlanguage-link-target">Русский</a></li><li class="interlanguage-link interwiki-simple"><a href="https://simple.wiktionary.org/wiki/correspondent" title="correspondent – Simple English" lang="en-simple" hreflang="en-simple" class="interlanguage-link-target">Simple English</a></li><li class="interlanguage-link interwiki-sd"><a href="https://sd.wiktionary.org/wiki/correspondent" title="correspondent – Sindhi" lang="sd" hreflang="sd" class="interlanguage-link-target">سنڌي</a></li><li class="interlanguage-link interwiki-fi"><a href="https://fi.wiktionary.org/wiki/correspondent" title="correspondent – Finnish" lang="fi" hreflang="fi" class="interlanguage-link-target">Suomi</a></li><li class="interlanguage-link interwiki-ta"><a href="https://ta.wiktionary.org/wiki/correspondent" title="correspondent – Tamil" lang="ta" hreflang="ta" class="interlanguage-link-target">தமிழ்</a></li><li class="interlanguage-link interwiki-te"><a href="https://te.wiktionary.org/wiki/correspondent" title="correspondent – Telugu" lang="te" hreflang="te" class="interlanguage-link-target">తెలుగు</a></li><li class="interlanguage-link interwiki-chr"><a href="https://chr.wiktionary.org/wiki/correspondent" title="correspondent – Cherokee" lang="chr" hreflang="chr" class="interlanguage-link-target">ᏣᎳᎩ</a></li><li class="interlanguage-link interwiki-ur"><a href="https://ur.wiktionary.org/wiki/correspondent" title="correspondent – Urdu" lang="ur" hreflang="ur" class="interlanguage-link-target">اردو</a></li><li class="interlanguage-link interwiki-vi"><a href="https://vi.wiktionary.org/wiki/correspondent" title="correspondent – Vietnamese" lang="vi" hreflang="vi" class="interlanguage-link-target">Tiếng Việt</a></li><li class="interlanguage-link interwiki-zh"><a href="https://zh.wiktionary.org/wiki/correspondent" title="correspondent – Chinese" lang="zh" hreflang="zh" class="interlanguage-link-target">中文</a></li></ul>
+
+	</div>
+</nav>
+
+</div>
+
+</div>
+<footer id="footer" class="mw-footer" role="contentinfo" >
+	<ul id="footer-info" >
+	<li id="footer-info-lastmod"> This page was last edited on 7 November 2020, at 15:32.</li>
+	<li id="footer-info-copyright">Text is available under the <a href="//creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike License</a>; additional terms may apply.  By using this site, you agree to the <a href="//wikimediafoundation.org/wiki/Terms_of_Use">Terms of Use</a> and <a href="//wikimediafoundation.org/wiki/Privacy_policy">Privacy Policy.</a></li>
+</ul>
+
+	<ul id="footer-places" >
+	<li id="footer-places-privacy"><a href="https://foundation.wikimedia.org/wiki/Privacy_policy" class="extiw" title="wmf:Privacy policy">Privacy policy</a></li>
+	<li id="footer-places-about"><a href="/wiki/Wiktionary:About" class="mw-redirect" title="Wiktionary:About">About Wiktionary</a></li>
+	<li id="footer-places-disclaimer"><a href="/wiki/Wiktionary:General_disclaimer" title="Wiktionary:General disclaimer">Disclaimers</a></li>
+	<li id="footer-places-mobileview"><a href="//en.m.wiktionary.org/w/index.php?title=correspondent&amp;mobileaction=toggle_view_mobile" class="noprint stopMobileRedirectToggle">Mobile view</a></li>
+	<li id="footer-places-developers"><a href="https://www.mediawiki.org/wiki/Special:MyLanguage/How_to_contribute">Developers</a></li>
+	<li id="footer-places-statslink"><a href="https://stats.wikimedia.org/#/en.wiktionary.org">Statistics</a></li>
+	<li id="footer-places-cookiestatement"><a href="https://foundation.wikimedia.org/wiki/Cookie_statement">Cookie statement</a></li>
+</ul>
+
+	<ul id="footer-icons" class="noprint">
+	<li id="footer-copyrightico"><a href="https://wikimediafoundation.org/"><img src="/static/images/footer/wikimedia-button.png" srcset="/static/images/footer/wikimedia-button-1.5x.png 1.5x, /static/images/footer/wikimedia-button-2x.png 2x" width="88" height="31" alt="Wikimedia Foundation" loading="lazy" /></a></li>
+	<li id="footer-poweredbyico"><a href="https://www.mediawiki.org/"><img src="/static/images/footer/poweredby_mediawiki_88x31.png" alt="Powered by MediaWiki" srcset="/static/images/footer/poweredby_mediawiki_132x47.png 1.5x, /static/images/footer/poweredby_mediawiki_176x62.png 2x" width="88" height="31" loading="lazy"/></a></li>
+</ul>
+
+	<div style="clear: both;"></div>
+</footer>
+
+
+<script>(RLQ=window.RLQ||[]).push(function(){mw.config.set({"wgPageParseReport":{"limitreport":{"cputime":"0.844","walltime":"1.132","ppvisitednodes":{"value":16217,"limit":1000000},"postexpandincludesize":{"value":63301,"limit":2097152},"templateargumentsize":{"value":15234,"limit":2097152},"expansiondepth":{"value":28,"limit":40},"expensivefunctioncount":{"value":9,"limit":500},"unstrip-depth":{"value":0,"limit":20},"unstrip-size":{"value":330,"limit":5000000},"entityaccesscount":{"value":0,"limit":400},"timingprofile":["100.00% 1009.255      1 -total"," 21.26%  214.527     14 Template:check_deprecated_lang_param_usage"," 20.83%  210.190     14 Template:deprecated_code"," 20.21%  203.939     23 Template:t+"," 17.20%  173.604     37 Template:redlink_category"," 12.61%  127.264      4 Template:der","  6.57%   66.314      2 Template:lb","  6.49%   65.523      8 Template:t","  6.37%   64.301      3 Template:IPA","  5.41%   54.622      3 Template:inflection_of"]},"scribunto":{"limitreport-timeusage":{"value":"0.409","limit":"10.000"},"limitreport-memusage":{"value":16158856,"limit":52428800}},"cachereport":{"origin":"mw1294","timestamp":"20201113204328","ttl":86400,"transientcontent":true}}});mw.config.set({"wgBackendResponseTime":113,"wgHostname":"mw1385"});});</script>
+</body></html>

--- a/tests/testOutput.json
+++ b/tests/testOutput.json
@@ -77,6 +77,54 @@
                 }
             }
         ],
+        "correspondent": [
+            {
+                "etymology": "From Latin, via Middle French or directly, from Medieval Latin correspond\u0113ns, present participle of corresponde\u014d.\n",
+                "definitions": [
+                    {
+                        "partOfSpeech": "adjective",
+                        "text": [
+                            "correspondent (comparative more correspondent, superlative most correspondent)",
+                            "Corresponding; suitable; adapted; congruous.",
+                            "(with to or with) Conforming; obedient."
+                        ],
+                        "relatedWords": [],
+                        "examples": [
+                            "Action correspondent or repugnant unto the law.",
+                            "[VV]e are able with playne demon\u017ftration to proue, and vvith rea\u017fon to per\u017fvvade that in tymes pa\u017ft our fayth vvas alike, that then vve preached thinges corre\u017fpondent vnto the forme of faith already published of vs, \u017fo that none in this behalfe can repyne or gaynesay vs.",
+                            "ARIEL: Pardon, master: / I will be correspondent to command, / And do my spriting gently."
+                        ]
+                    },
+                    {
+                        "partOfSpeech": "noun",
+                        "text": [
+                            "correspondent (plural correspondents)",
+                            "Someone who or something which corresponds.",
+                            "Someone who communicates with another person, or a publication, by writing.",
+                            "A journalist who sends reports back to a newspaper or radio or television station from a distant or overseas location."
+                        ],
+                        "relatedWords": [
+                            {
+                                "relationshipType": "hyponyms",
+                                "words": [
+                                    "stringer"
+                                ]
+                            }
+                        ],
+                        "examples": []
+                    }
+                ],
+                "pronunciations": {
+                    "text": [
+                        "(Received Pronunciation) IPA: /\u02cck\u0252\u0279\u026a\u02c8sp\u0252nd\u0259nt/",
+                        "(General American) IPA: /\u02cck\u0254\u0279\u026a\u02c8sp\u0251nd\u0259nt/"
+                    ],
+                    "audio": [
+                        "//upload.wikimedia.org/wikipedia/commons/transcoded/5/58/En-us-correspondent.ogg/En-us-correspondent.ogg.mp3"
+                    ]
+                }
+            }
+        ],
         "grapple": [
             {
                 "etymology": "From Middle English *grapplen (\u201cto seize, lay hold of\u201d), from Old English *gr\u00e6pplian (\u201cto seize\u201d) (compare Old English \u0121egr\u00e6ppian (\u201cto seize\u201d)), from Proto-Germanic *graipil\u014dn\u0105, *grabbal\u014dn\u0105 (\u201cto seize\u201d), from Proto-Indo-European *ghreb(h)-, *ghrab(h)- (\u201cto take, seize, rake\u201d), equivalent to grab +\u200e -le. Cognate with Dutch grabbelen (\u201cto grope, scramble, scrabble\u201d), German grabbeln (\u201cto rummage, grope about\u201d) and grapsen, grapschen (\u201cto seize, grasp, grabble\u201d). Influenced in some senses by grapple (\u201ctool with claws or hooks\u201d, noun) (see below). See further at grasp.\n",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,6 +24,7 @@ test_words = [
     ('alexin', 50152026, ['English']),
     ('song', 60388804, ['English']),
     ('house', 50356446, ['English']),
+    ('correspondent', 61052028, ['English']),
     ('video', 50291344, ['Latin']),
     ('seg', 50359832, ['Norwegian Bokmål']),
     ('aldersblandet', 38616917, ['Norwegian Bokmål']),

--- a/wiktionaryparser/core.py
+++ b/wiktionaryparser/core.py
@@ -180,7 +180,8 @@ class WiktionaryParser(object):
                 definition_tag = table
                 table = table.find_next_sibling()
                 if definition_tag.name == 'p':
-                    definition_text.append(definition_tag.text.strip())
+                    if definition_tag.text.strip():
+                        definition_text.append(definition_tag.text.strip())
                 if definition_tag.name in ['ol', 'ul']:
                     for element in definition_tag.find_all('li', recursive=False):
                         if element.text:


### PR DESCRIPTION
For the word "correspondent," an empty `<p>` between a "Tea Room"
block and the word entry itself caused the first definition to be
an empty string. This change strips this empty string to ensure
that each definition contains actual content.