### PR TITLE
pronunciation parsing for heteronyms

### DIFF
--- a/wiktionaryparser/core.py
+++ b/wiktionaryparser/core.py
@@ -143,9 +143,9 @@ class WiktionaryParser(object):
         pronunciation_id_list = self.get_id_list(word_contents, 'pronunciation')
         pronunciation_list = []
         audio_links = []
-        pronunciation_text = []
         pronunciation_div_classes = ['mw-collapsible', 'vsSwitcher']
         for pronunciation_index, pronunciation_id, _ in pronunciation_id_list:
+            pronunciation_text = []
             span_tag = self.soup.find_all('span', {'id': pronunciation_id})[0]
             list_tag = span_tag.parent
             while list_tag.name != 'ul':


### PR DESCRIPTION
For words that are heteronyms, the pronunciation parser does not work properly. 
For example, when we fetch the word 'bass' by executing 
> parser.fetch('bass')

the first definition should contain the pronunciation _'enPR: bās, IPA: /beɪs/'_ only, not the other pronunciations such as _'enPR: băs, IPA: /bæs/'_.  
I think this is a critical issue, since heteronyms such as the example 'bass' above have different meanings when pronounced differently. The revised code resolves this problem.