### PR TITLE
Modularize WiktionaryParser

### DIFF
--- a/tests/html_test_files/hodati-60892603.html
+++ b/tests/html_test_files/hodati-60892603.html
@@ -1,0 +1,4868 @@
+<!DOCTYPE html>
+<!-- saved from url=(0065)https://en.wiktionary.org/w/index.php?title=hodati&oldid=60892603 -->
+<html class="client-js ve-not-available" lang="en" dir="ltr">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+    <title>hodati - Wiktionary</title>
+    <script>document.documentElement.className = "client-js";
+    RLCONF = {
+        "wgBreakFrames": !1,
+        "wgSeparatorTransformTable": ["", ""],
+        "wgDigitTransformTable": ["", ""],
+        "wgDefaultDateFormat": "dmy",
+        "wgMonthNames": ["", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+        "wgRequestId": "baa72eae-5fcf-41aa-8dcf-c05b815a43f7",
+        "wgCSPNonce": !1,
+        "wgCanonicalNamespace": "",
+        "wgCanonicalSpecialPageName": !1,
+        "wgNamespaceNumber": 0,
+        "wgPageName": "hodati",
+        "wgTitle": "hodati",
+        "wgCurRevisionId": 60892603,
+        "wgRevisionId": 60892603,
+        "wgArticleId": 816174,
+        "wgIsArticle": !0,
+        "wgIsRedirect": !1,
+        "wgAction": "view",
+        "wgUserName": null,
+        "wgUserGroups": ["*"],
+        "wgCategories": ["Serbo-Croatian terms with IPA pronunciation", "Serbo-Croatian lemmas", "Serbo-Croatian verbs", "Serbo-Croatian imperfective verbs", "Serbo-Croatian intransitive verbs", "Serbo-Croatian informal terms", "Croatian Serbo-Croatian"],
+        "wgPageContentLanguage": "en",
+        "wgPageContentModel": "wikitext",
+        "wgRelevantPageName": "hodati",
+        "wgRelevantArticleId": 816174,
+        "wgIsProbablyEditable": !0,
+        "wgRelevantPageIsProbablyEditable": !0,
+        "wgRestrictionEdit": [],
+        "wgRestrictionMove": [],
+        "wgMediaViewerOnClick": !0,
+        "wgMediaViewerEnabledByDefault": !0,
+        "wgVisualEditor": {"pageLanguageCode": "en", "pageLanguageDir": "ltr", "pageVariantFallbacks": "en"},
+        "wgMFDisplayWikibaseDescriptions": {"search": !0, "nearby": !0, "watchlist": !0, "tagline": !1},
+        "wgWMESchemaEditAttemptStepOversample": !1,
+        "wgULSCurrentAutonym": "English",
+        "wgNoticeProject": "wiktionary",
+        "wgEditSubmitButtonLabelPublish": !0,
+        "wgULSPosition": "interlanguage",
+        "wgULSisCompactLinksEnabled": !0,
+        "wgCentralAuthMobileDomain": !1
+    };
+    RLSTATE = {
+        "ext.gadget.column-hacks": "ready",
+        "ext.globalCssJs.user.styles": "ready",
+        "site.styles": "ready",
+        "noscript": "ready",
+        "user.styles": "ready",
+        "ext.globalCssJs.user": "ready",
+        "user": "ready",
+        "user.options": "loading",
+        "mediawiki.action.styles": "ready",
+        "mediawiki.interface.helpers.styles": "ready",
+        "skins.vector.styles.legacy": "ready",
+        "ext.visualEditor.desktopArticleTarget.noscript": "ready",
+        "ext.uls.interlanguage": "ready",
+        "ext.wikimediaBadges": "ready"
+    };
+    RLPAGEMODULES = ["site", "mediawiki.page.ready", "mediawiki.toc", "skins.vector.legacy.js", "ext.gadget.LegacyScripts", "ext.gadget.JavascriptHeadings", "ext.gadget.TargetedTranslations", "ext.gadget.DocTabs", "ext.gadget.BlockInfo", "ext.gadget.RevdelInfo", "ext.gadget.CodeLinks", "ext.gadget.TranslationAdder", "ext.gadget.RhymesAdder", "ext.gadget.SpecialSearch", "ext.gadget.zhDialMap", "ext.gadget.catfix", "ext.gadget.Edittools", "ext.gadget.defaultVisibilityToggles", "ext.visualEditor.desktopArticleTarget.init", "ext.visualEditor.targetLoader", "ext.eventLogging", "ext.wikimediaEvents", "ext.navigationTiming", "ext.uls.compactlinks", "ext.uls.interface", "ext.centralNotice.geoIP", "ext.centralNotice.startUp", "ext.centralauth.centralautologin"];</script>
+    <script>(RLQ = window.RLQ || []).push(function () {
+        mw.loader.implement("user.options@1hzgi", function ($, jQuery, require, module) {/*@nomin*/
+            mw.user.tokens.set({"patrolToken": "+\\", "watchToken": "+\\", "csrfToken": "+\\"});
+        });
+    });</script>
+    <link rel="stylesheet" href="./hodati-60892603_files/load.php">
+    <script async="" src="./hodati-60892603_files/load(1).php"></script>
+    <style>
+        .mw-editfont-monospace {
+            font-family: monospace, monospace
+        }
+
+        .mw-editfont-sans-serif {
+            font-family: sans-serif
+        }
+
+        .mw-editfont-serif {
+            font-family: serif
+        }
+
+        .mw-editfont-monospace, .mw-editfont-sans-serif, .mw-editfont-serif {
+            font-size: 13px;
+            -moz-tab-size: 4;
+            tab-size: 4;
+        }
+
+        .mw-editfont-monospace.oo-ui-textInputWidget, .mw-editfont-sans-serif.oo-ui-textInputWidget, .mw-editfont-serif.oo-ui-textInputWidget {
+            font-size: inherit
+        }
+
+        .mw-editfont-monospace.oo-ui-textInputWidget > .oo-ui-inputWidget-input, .mw-editfont-sans-serif.oo-ui-textInputWidget > .oo-ui-inputWidget-input, .mw-editfont-serif.oo-ui-textInputWidget > .oo-ui-inputWidget-input {
+            font-size: 13px
+        }
+
+        .mw-editfont-monospace.oo-ui-textInputWidget > input.oo-ui-inputWidget-input, .mw-editfont-sans-serif.oo-ui-textInputWidget > input.oo-ui-inputWidget-input, .mw-editfont-serif.oo-ui-textInputWidget > input.oo-ui-inputWidget-input {
+            min-height: 32px
+        }
+
+        .mw-ui-button {
+            background-color: #f8f9fa;
+            color: #202122;
+            display: inline-block;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            border: 1px solid #a2a9b1;
+            border-radius: 2px;
+            cursor: pointer;
+            vertical-align: middle;
+            font-family: inherit;
+            font-size: 1em;
+            font-weight: bold;
+            line-height: 1.28571429em;
+            text-align: center;
+            -webkit-appearance: none
+        }
+
+        .mw-ui-button:not(.mw-ui-icon-element) {
+            min-height: 32px;
+            min-width: 4em;
+            max-width: 28.75em;
+            margin: 0;
+            padding: 5px 12px
+        }
+
+        .mw-ui-button:not(:disabled) {
+            -webkit-transition: background-color 100ms, color 100ms, border-color 100ms, box-shadow 100ms;
+            transition: background-color 100ms, color 100ms, border-color 100ms, box-shadow 100ms
+        }
+
+        .mw-ui-button:not(:disabled):visited {
+            color: #202122
+        }
+
+        .mw-ui-button:not(:disabled):hover {
+            background-color: #ffffff;
+            color: #404244;
+            border-color: #a2a9b1
+        }
+
+        .mw-ui-button:not(:disabled):focus {
+            color: #202122;
+            border-color: #3366cc;
+            box-shadow: inset 0 0 0 1px #3366cc, inset 0 0 0 2px #ffffff;
+            outline-width: 0
+        }
+
+        .mw-ui-button:not(:disabled):focus::-moz-focus-inner {
+            border-color: transparent;
+            padding: 0
+        }
+
+        .mw-ui-button:not(:disabled):active, .mw-ui-button:not(:disabled).is-on {
+            background-color: #c8ccd1;
+            color: #000000;
+            border-color: #72777d;
+            box-shadow: none
+        }
+
+        .mw-ui-button:disabled {
+            background-color: #c8ccd1;
+            color: #ffffff;
+            border-color: #c8ccd1;
+            cursor: default
+        }
+
+        .mw-ui-button.mw-ui-icon-element:not(.mw-ui-icon-with-label-desktop) {
+            color: transparent !important
+        }
+
+        .mw-ui-button.mw-ui-icon-element:not(.mw-ui-icon-with-label-desktop) span {
+            display: block;
+            position: absolute !important;
+            clip: rect(1px, 1px, 1px, 1px);
+            width: 1px;
+            height: 1px;
+            margin: -1px;
+            border: 0;
+            padding: 0;
+            overflow: hidden
+        }
+
+        @media all and (max-width: 1000px) {
+            .mw-ui-button.mw-ui-icon-element.mw-ui-icon-with-label-desktop {
+                color: transparent !important
+            }
+
+            .mw-ui-button.mw-ui-icon-element span {
+                display: block;
+                position: absolute !important;
+                clip: rect(1px, 1px, 1px, 1px);
+                width: 1px;
+                height: 1px;
+                margin: -1px;
+                border: 0;
+                padding: 0;
+                overflow: hidden
+            }
+        }
+
+        .mw-ui-button.mw-ui-quiet, .mw-ui-button.mw-ui-quiet.mw-ui-progressive, .mw-ui-button.mw-ui-quiet.mw-ui-destructive {
+            background-color: transparent;
+            color: #202122;
+            border-color: transparent;
+            font-weight: bold
+        }
+
+        .mw-ui-button.mw-ui-quiet:not(.mw-ui-icon-element), .mw-ui-button.mw-ui-quiet.mw-ui-progressive:not(.mw-ui-icon-element), .mw-ui-button.mw-ui-quiet.mw-ui-destructive:not(.mw-ui-icon-element) {
+            min-height: 32px
+        }
+
+        input[type='checkbox']:hover + .mw-ui-button.mw-ui-quiet, input[type='checkbox']:hover + .mw-ui-button.mw-ui-quiet.mw-ui-progressive, input[type='checkbox']:hover + .mw-ui-button.mw-ui-quiet.mw-ui-destructive, .mw-ui-button.mw-ui-quiet:hover, .mw-ui-button.mw-ui-quiet.mw-ui-progressive:hover, .mw-ui-button.mw-ui-quiet.mw-ui-destructive:hover {
+            background-color: rgba(0, 24, 73, 0.02745098);
+            color: #202122;
+            border-color: transparent
+        }
+
+        input[type='checkbox']:focus + .mw-ui-button.mw-ui-quiet, input[type='checkbox']:focus + .mw-ui-button.mw-ui-quiet.mw-ui-progressive, input[type='checkbox']:focus + .mw-ui-button.mw-ui-quiet.mw-ui-destructive, .mw-ui-button.mw-ui-quiet:focus, .mw-ui-button.mw-ui-quiet.mw-ui-progressive:focus, .mw-ui-button.mw-ui-quiet.mw-ui-destructive:focus {
+            color: #202122;
+            border-color: #3366cc;
+            box-shadow: inset 0 0 0 1px #3366cc, inset 0 0 0 2px #ffffff
+        }
+
+        input[type='checkbox']:active + .mw-ui-button.mw-ui-quiet, input[type='checkbox']:active + .mw-ui-button.mw-ui-quiet.mw-ui-progressive, input[type='checkbox']:active + .mw-ui-button.mw-ui-quiet.mw-ui-destructive, .mw-ui-button.mw-ui-quiet:active, .mw-ui-button.mw-ui-quiet.mw-ui-progressive:active, .mw-ui-button.mw-ui-quiet.mw-ui-destructive:active {
+            background-color: rgba(0, 36, 73, 0.08235294);
+            color: #000000;
+            border-color: #72777d;
+            box-shadow: none
+        }
+
+        .mw-ui-button.mw-ui-quiet:disabled, .mw-ui-button.mw-ui-quiet.mw-ui-progressive:disabled, .mw-ui-button.mw-ui-quiet.mw-ui-destructive:disabled, .mw-ui-button.mw-ui-quiet:disabled:hover, .mw-ui-button.mw-ui-quiet.mw-ui-progressive:disabled:hover, .mw-ui-button.mw-ui-quiet.mw-ui-destructive:disabled:hover, .mw-ui-button.mw-ui-quiet:disabled:active, .mw-ui-button.mw-ui-quiet.mw-ui-progressive:disabled:active, .mw-ui-button.mw-ui-quiet.mw-ui-destructive:disabled:active {
+            background-color: transparent;
+            color: #72777d;
+            border-color: transparent
+        }
+
+        .mw-ui-button.mw-ui-progressive:not(:disabled) {
+            background-color: #3366cc;
+            color: #fff;
+            border-color: #3366cc
+        }
+
+        .mw-ui-button.mw-ui-progressive:not(:disabled):hover {
+            background-color: #447ff5;
+            border-color: #447ff5
+        }
+
+        .mw-ui-button.mw-ui-progressive:not(:disabled):focus {
+            box-shadow: inset 0 0 0 1px #3366cc, inset 0 0 0 2px #ffffff
+        }
+
+        .mw-ui-button.mw-ui-progressive:not(:disabled):active, .mw-ui-button.mw-ui-progressive:not(:disabled).is-on {
+            background-color: #2a4b8d;
+            border-color: #2a4b8d;
+            box-shadow: none
+        }
+
+        .mw-ui-button.mw-ui-progressive:disabled {
+            background-color: #c8ccd1;
+            color: #fff;
+            border-color: #c8ccd1
+        }
+
+        .mw-ui-button.mw-ui-progressive.mw-ui-quiet {
+            color: #3366cc;
+            background-color: transparent;
+            border-color: transparent
+        }
+
+        input[type='checkbox']:hover + .mw-ui-button.mw-ui-progressive.mw-ui-quiet, .mw-ui-button.mw-ui-progressive.mw-ui-quiet:hover {
+            background-color: rgba(52, 123, 255, 0.2);
+            border-color: transparent;
+            color: #447ff5
+        }
+
+        input[type='checkbox']:focus + .mw-ui-button.mw-ui-progressive.mw-ui-quiet, .mw-ui-button.mw-ui-progressive.mw-ui-quiet:focus {
+            color: #3366cc;
+            border-color: #3366cc
+        }
+
+        input[type='checkbox']:active + .mw-ui-button.mw-ui-progressive.mw-ui-quiet, .mw-ui-button.mw-ui-progressive.mw-ui-quiet:active {
+            color: #ffffff;
+            background-color: #2a4b8d;
+            border-color: #2a4b8d
+        }
+
+        .mw-ui-button.mw-ui-destructive:not(:disabled) {
+            background-color: #dd3333;
+            color: #fff;
+            border-color: #dd3333
+        }
+
+        .mw-ui-button.mw-ui-destructive:not(:disabled):hover {
+            background-color: #ff4242;
+            border-color: #ff4242
+        }
+
+        .mw-ui-button.mw-ui-destructive:not(:disabled):focus {
+            box-shadow: inset 0 0 0 1px #dd3333, inset 0 0 0 2px #ffffff
+        }
+
+        .mw-ui-button.mw-ui-destructive:not(:disabled):active, .mw-ui-button.mw-ui-destructive:not(:disabled).is-on {
+            background-color: #b32424;
+            border-color: #b32424;
+            box-shadow: none
+        }
+
+        .mw-ui-button.mw-ui-destructive:disabled {
+            background-color: #c8ccd1;
+            color: #fff;
+            border-color: #c8ccd1
+        }
+
+        .mw-ui-button.mw-ui-destructive.mw-ui-quiet {
+            color: #dd3333;
+            background-color: transparent;
+            border-color: transparent
+        }
+
+        input[type='checkbox']:hover + .mw-ui-button.mw-ui-destructive.mw-ui-quiet, .mw-ui-button.mw-ui-destructive.mw-ui-quiet:hover {
+            background-color: rgba(209, 29, 19, 0.2);
+            border-color: transparent;
+            color: #ff4242
+        }
+
+        input[type='checkbox']:focus + .mw-ui-button.mw-ui-destructive.mw-ui-quiet, .mw-ui-button.mw-ui-destructive.mw-ui-quiet:focus {
+            color: #dd3333;
+            border-color: #dd3333
+        }
+
+        input[type='checkbox']:active + .mw-ui-button.mw-ui-destructive.mw-ui-quiet, .mw-ui-button.mw-ui-destructive.mw-ui-quiet:active {
+            color: #ffffff;
+            background-color: #b32424;
+            border-color: #b32424
+        }
+
+        .mw-ui-button.mw-ui-big {
+            font-size: 1.3em
+        }
+
+        .mw-ui-button.mw-ui-block {
+            display: block;
+            width: 100%;
+            margin-left: auto;
+            margin-right: auto
+        }
+
+        a.mw-ui-button {
+            text-decoration: none
+        }
+
+        a.mw-ui-button:hover, a.mw-ui-button:focus {
+            text-decoration: none
+        }
+
+        .mw-ui-button-group > * {
+            min-width: 48px;
+            border-radius: 0;
+            float: left
+        }
+
+        .mw-ui-button-group > *:first-child {
+            border-top-left-radius: 2px;
+            border-bottom-left-radius: 2px
+        }
+
+        .mw-ui-button-group > *:not(:first-child) {
+            border-left: 0
+        }
+
+        .mw-ui-button-group > *:last-child {
+            border-top-right-radius: 2px;
+            border-bottom-right-radius: 2px
+        }
+
+        .mw-ui-button-group .is-on .button {
+            cursor: default
+        }
+
+        .oo-ui-element-hidden {
+            display: none !important
+        }
+
+        .oo-ui-buttonElement {
+            display: inline-block;
+            line-height: normal;
+            vertical-align: middle
+        }
+
+        .oo-ui-buttonElement > .oo-ui-buttonElement-button {
+            cursor: pointer;
+            display: inline-block;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            vertical-align: middle;
+            font-family: inherit;
+            font-size: inherit;
+            white-space: nowrap;
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none
+        }
+
+        .oo-ui-buttonElement > .oo-ui-buttonElement-button::-moz-focus-inner {
+            border-color: transparent;
+            padding: 0
+        }
+
+        .oo-ui-buttonElement.oo-ui-widget-disabled > .oo-ui-buttonElement-button {
+            cursor: default
+        }
+
+        .oo-ui-buttonElement-frameless {
+            position: relative
+        }
+
+        .oo-ui-buttonElement-framed > .oo-ui-buttonElement-button {
+            vertical-align: top;
+            text-align: center
+        }
+
+        .oo-ui-buttonElement > .oo-ui-buttonElement-button {
+            position: relative;
+            min-height: 32px;
+            border-radius: 2px;
+            padding-top: 2.14285714em;
+            font-weight: bold;
+            text-decoration: none
+        }
+
+        .oo-ui-buttonElement > .oo-ui-buttonElement-button:focus {
+            outline: 0
+        }
+
+        .oo-ui-buttonElement > input.oo-ui-buttonElement-button {
+            -webkit-appearance: none
+        }
+
+        .oo-ui-buttonElement.oo-ui-labelElement > .oo-ui-buttonElement-button {
+            line-height: 1
+        }
+
+        .oo-ui-buttonElement.oo-ui-labelElement > input.oo-ui-buttonElement-button, .oo-ui-buttonElement.oo-ui-labelElement > .oo-ui-buttonElement-button > .oo-ui-labelElement-label {
+            line-height: 1.42857143em
+        }
+
+        .oo-ui-buttonElement.oo-ui-labelElement.oo-ui-indicatorElement > .oo-ui-buttonElement-button {
+            padding-right: 2.14285714em
+        }
+
+        .oo-ui-buttonElement.oo-ui-iconElement .oo-ui-iconElement-icon, .oo-ui-buttonElement.oo-ui-indicatorElement .oo-ui-indicatorElement-indicator {
+            -webkit-transform: translateZ(0);
+            transform: translateZ(0)
+        }
+
+        .oo-ui-buttonElement.oo-ui-indicatorElement.oo-ui-labelElement > .oo-ui-buttonElement-button > .oo-ui-indicatorElement-indicator, .oo-ui-buttonElement.oo-ui-indicatorElement.oo-ui-iconElement > .oo-ui-buttonElement-button > .oo-ui-indicatorElement-indicator {
+            right: 0.71428571em
+        }
+
+        .oo-ui-buttonElement.oo-ui-widget-enabled > .oo-ui-buttonElement-button {
+            -webkit-transition: background-color 100ms, color 100ms, border-color 100ms, box-shadow 100ms;
+            transition: background-color 100ms, color 100ms, border-color 100ms, box-shadow 100ms
+        }
+
+        .oo-ui-buttonElement.oo-ui-widget-enabled > .oo-ui-buttonElement-button > .oo-ui-iconElement-icon, .oo-ui-buttonElement.oo-ui-widget-enabled > .oo-ui-buttonElement-button > .oo-ui-indicatorElement-indicator {
+            -webkit-transition: opacity 100ms;
+            transition: opacity 100ms
+        }
+
+        .oo-ui-buttonElement.oo-ui-widget-enabled > .oo-ui-buttonElement-button > .oo-ui-iconElement-icon:not(.oo-ui-image-invert), .oo-ui-buttonElement.oo-ui-widget-enabled > .oo-ui-buttonElement-button > .oo-ui-indicatorElement-indicator:not(.oo-ui-image-invert) {
+            opacity: 0.87
+        }
+
+        .oo-ui-buttonElement.oo-ui-widget-enabled.oo-ui-buttonElement-pressed > .oo-ui-buttonElement-button > .oo-ui-iconElement-icon, .oo-ui-buttonElement.oo-ui-widget-enabled.oo-ui-buttonElement-pressed > .oo-ui-buttonElement-button > .oo-ui-indicatorElement-indicator {
+            opacity: 1
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-iconElement:first-child {
+            margin-left: -0.42857143em
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-iconElement > .oo-ui-buttonElement-button {
+            min-width: 32px;
+            min-height: 32px;
+            border-color: transparent;
+            border-style: solid;
+            border-width: 1px;
+            padding-top: 2.14285714em;
+            padding-left: 2.14285714em
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-iconElement > .oo-ui-buttonElement-button > .oo-ui-iconElement-icon {
+            left: 0.35714286em
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-labelElement:first-child {
+            margin-left: -6px
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-labelElement.oo-ui-iconElement:first-child {
+            margin-left: -0.42857143em
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-labelElement > .oo-ui-buttonElement-button {
+            border-color: transparent;
+            border-style: solid;
+            border-width: 1px;
+            padding: 5px 6px
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-labelElement.oo-ui-iconElement > .oo-ui-buttonElement-button {
+            padding-left: 2.14285714em
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-indicatorElement:not(.oo-ui-iconElement):not(.oo-ui-labelElement) > .oo-ui-buttonElement-button {
+            min-width: 12px
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-indicatorElement.oo-ui-iconElement > .oo-ui-buttonElement-button {
+            padding-left: 3.85714286em
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-indicatorElement.oo-ui-labelElement > .oo-ui-buttonElement-button {
+            padding-left: 6px;
+            padding-top: 5px
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-indicatorElement.oo-ui-iconElement.oo-ui-labelElement > .oo-ui-buttonElement-button {
+            padding-left: 2.14285714em
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled > .oo-ui-buttonElement-button {
+            color: #202122
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled > .oo-ui-buttonElement-button:hover {
+            background-color: rgba(0, 24, 73, 7/255);
+            color: #000
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled > .oo-ui-buttonElement-button:focus {
+            border-color: #36c;
+            box-shadow: inset 0 0 0 1px #36c;
+            outline: 1px solid transparent
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled.oo-ui-buttonElement-pressed > input.oo-ui-buttonElement-button, .oo-ui-buttonElement-frameless.oo-ui-widget-enabled > .oo-ui-buttonElement-button:active {
+            background-color: rgba(0, 36, 73, 21/255);
+            color: #000;
+            border-color: #72777d;
+            box-shadow: none
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled.oo-ui-indicatorElement:not(.oo-ui-iconElement):not(.oo-ui-labelElement) > .oo-ui-buttonElement-button {
+            border-radius: 1px
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled.oo-ui-indicatorElement:not(.oo-ui-iconElement):not(.oo-ui-labelElement) > .oo-ui-buttonElement-button:focus {
+            box-shadow: 0 0 0 2px #36c
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled.oo-ui-indicatorElement:not(.oo-ui-iconElement):not(.oo-ui-labelElement) > .oo-ui-buttonElement-button:active {
+            box-shadow: none
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled.oo-ui-flaggedElement-progressive > .oo-ui-buttonElement-button {
+            color: #36c
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled.oo-ui-flaggedElement-progressive > .oo-ui-buttonElement-button:hover {
+            color: #447ff5
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled.oo-ui-flaggedElement-progressive > .oo-ui-buttonElement-button:active, .oo-ui-buttonElement-frameless.oo-ui-widget-enabled.oo-ui-flaggedElement-progressive.oo-ui-buttonElement-pressed > .oo-ui-buttonElement-button {
+            color: #2a4b8d;
+            border-color: #2a4b8d;
+            box-shadow: none
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled.oo-ui-flaggedElement-destructive > .oo-ui-buttonElement-button {
+            color: #d33
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled.oo-ui-flaggedElement-destructive > .oo-ui-buttonElement-button:hover {
+            color: #ff4242
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled.oo-ui-flaggedElement-destructive > .oo-ui-buttonElement-button:active, .oo-ui-buttonElement-frameless.oo-ui-widget-enabled.oo-ui-flaggedElement-destructive.oo-ui-buttonElement-pressed > .oo-ui-buttonElement-button {
+            color: #b32424;
+            border-color: #b32424;
+            box-shadow: none
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-enabled[class*='oo-ui-flaggedElement'] > .oo-ui-buttonElement-button > .oo-ui-iconElement-icon, .oo-ui-buttonElement-frameless.oo-ui-widget-enabled[class*='oo-ui-flaggedElement'] > .oo-ui-buttonElement-button > .oo-ui-indicatorElement-indicator {
+            opacity: 1
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-disabled > .oo-ui-buttonElement-button {
+            color: #72777d
+        }
+
+        .oo-ui-buttonElement-frameless.oo-ui-widget-disabled > .oo-ui-buttonElement-button > .oo-ui-iconElement-icon, .oo-ui-buttonElement-frameless.oo-ui-widget-disabled > .oo-ui-buttonElement-button > .oo-ui-indicatorElement-indicator {
+            opacity: 0.51
+        }
+
+        .oo-ui-buttonElement-framed > .oo-ui-buttonElement-button {
+            border-style: solid;
+            border-width: 1px;
+            border-radius: 2px;
+            padding-left: 12px;
+            padding-right: 12px
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-iconElement > .oo-ui-buttonElement-button {
+            padding-top: 2.14285714em;
+            padding-bottom: 0;
+            padding-left: 2.14285714em
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-iconElement > .oo-ui-buttonElement-button > .oo-ui-iconElement-icon {
+            left: 50%;
+            margin-left: -0.71428571em
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-iconElement.oo-ui-labelElement > .oo-ui-buttonElement-button, .oo-ui-buttonElement-framed.oo-ui-iconElement.oo-ui-indicatorElement > .oo-ui-buttonElement-button {
+            padding-left: 2.71428571em
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-iconElement.oo-ui-labelElement > .oo-ui-buttonElement-button > .oo-ui-iconElement-icon, .oo-ui-buttonElement-framed.oo-ui-iconElement.oo-ui-indicatorElement > .oo-ui-buttonElement-button > .oo-ui-iconElement-icon {
+            left: 0.78571429em;
+            margin-left: 0
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-indicatorElement > .oo-ui-buttonElement-button {
+            padding-top: 2.14285714em;
+            padding-right: 1.71428571em;
+            padding-bottom: 0
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-labelElement > .oo-ui-buttonElement-button {
+            padding-top: 5px;
+            padding-bottom: 5px
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-disabled > .oo-ui-buttonElement-button {
+            background-color: #c8ccd1;
+            color: #fff;
+            border-color: #c8ccd1
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-disabled.oo-ui-buttonElement-active > .oo-ui-buttonElement-button {
+            background-color: #919fb9
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled > .oo-ui-buttonElement-button {
+            background-color: #f8f9fa;
+            color: #202122;
+            border-color: #a2a9b1
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled > .oo-ui-buttonElement-button:hover {
+            background-color: #fff;
+            color: #404244;
+            border-color: #a2a9b1
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled > .oo-ui-buttonElement-button:hover > .oo-ui-iconElement-icon:not(.oo-ui-image-invert), .oo-ui-buttonElement-framed.oo-ui-widget-enabled > .oo-ui-buttonElement-button:hover > .oo-ui-indicatorElement-indicator:not(.oo-ui-image-invert) {
+            opacity: 0.74
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled > .oo-ui-buttonElement-button:focus {
+            border-color: #36c;
+            box-shadow: inset 0 0 0 1px #36c;
+            outline: 1px solid transparent
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-buttonElement-active > .oo-ui-buttonElement-button {
+            background-color: #2a4b8d;
+            color: #fff;
+            border-color: #2a4b8d
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-buttonElement-active > .oo-ui-buttonElement-button:focus {
+            border-color: #36c;
+            box-shadow: inset 0 0 0 1px #36c, inset 0 0 0 2px #fff
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled > .oo-ui-buttonElement-button:active, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-buttonElement-pressed > .oo-ui-buttonElement-button {
+            background-color: #c8ccd1;
+            color: #000;
+            border-color: #72777d;
+            box-shadow: none
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-progressive > .oo-ui-buttonElement-button {
+            color: #36c
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-progressive > .oo-ui-buttonElement-button:hover {
+            background-color: #fff;
+            border-color: #447ff5
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-progressive > .oo-ui-buttonElement-button:focus {
+            border-color: #36c;
+            box-shadow: inset 0 0 0 1px #36c;
+            outline: 1px solid transparent
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-progressive > .oo-ui-buttonElement-button:active, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-progressive.oo-ui-buttonElement-pressed > .oo-ui-buttonElement-button, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-progressive.oo-ui-buttonElement-active > .oo-ui-buttonElement-button, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-progressive.oo-ui-popupToolGroup-active > .oo-ui-buttonElement-button {
+            background-color: #eff3fa;
+            color: #2a4b8d;
+            border-color: #2a4b8d;
+            box-shadow: none
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-destructive > .oo-ui-buttonElement-button {
+            color: #d73333
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-destructive > .oo-ui-buttonElement-button:hover {
+            background-color: #fff;
+            border-color: #ff4242
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-destructive > .oo-ui-buttonElement-button:focus {
+            border-color: #d33;
+            box-shadow: inset 0 0 0 1px #d33;
+            outline: 1px solid transparent
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-destructive > .oo-ui-buttonElement-button:active, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-destructive.oo-ui-buttonElement-pressed > .oo-ui-buttonElement-button, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-destructive.oo-ui-buttonElement-active > .oo-ui-buttonElement-button, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-destructive.oo-ui-popupToolGroup-active > .oo-ui-buttonElement-button {
+            background-color: #ffffff;
+            color: #b32424;
+            border-color: #b32424;
+            box-shadow: none
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-progressive > .oo-ui-buttonElement-button {
+            color: #fff;
+            background-color: #36c;
+            border-color: #36c
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-progressive > .oo-ui-buttonElement-button:hover {
+            background-color: #447ff5;
+            border-color: #447ff5
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-progressive > .oo-ui-buttonElement-button:focus {
+            border-color: #36c;
+            box-shadow: inset 0 0 0 1px #36c, inset 0 0 0 2px #fff;
+            outline: 1px solid transparent
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-progressive > .oo-ui-buttonElement-button:active, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-progressive.oo-ui-buttonElement-pressed > .oo-ui-buttonElement-button, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-progressive.oo-ui-buttonElement-active > .oo-ui-buttonElement-button, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-progressive.oo-ui-popupToolGroup-active > .oo-ui-buttonElement-button {
+            color: #fff;
+            background-color: #2a4b8d;
+            border-color: #2a4b8d;
+            box-shadow: none
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-destructive > .oo-ui-buttonElement-button {
+            color: #fff;
+            background-color: #d33;
+            border-color: #d33
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-destructive > .oo-ui-buttonElement-button:hover {
+            background-color: #ff4242;
+            border-color: #ff4242
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-destructive > .oo-ui-buttonElement-button:focus {
+            border-color: #d33;
+            box-shadow: inset 0 0 0 1px #d33, inset 0 0 0 2px #fff;
+            outline: 1px solid transparent
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-destructive > .oo-ui-buttonElement-button:active, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-destructive.oo-ui-buttonElement-pressed > .oo-ui-buttonElement-button, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-destructive.oo-ui-buttonElement-active > .oo-ui-buttonElement-button, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary.oo-ui-flaggedElement-destructive.oo-ui-popupToolGroup-active > .oo-ui-buttonElement-button {
+            color: #fff;
+            background-color: #b32424;
+            border-color: #b32424;
+            box-shadow: none
+        }
+
+        .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary > .oo-ui-buttonElement-button > .oo-ui-iconElement-icon, .oo-ui-buttonElement-framed.oo-ui-widget-enabled.oo-ui-flaggedElement-primary > .oo-ui-buttonElement-button > .oo-ui-indicatorElement-indicator {
+            opacity: 1
+        }
+
+        .oo-ui-clippableElement-clippable {
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            min-height: 40px;
+            -webkit-overflow-scrolling: touch
+        }
+
+        .oo-ui-floatableElement {
+            position: absolute
+        }
+
+        .oo-ui-labelElement .oo-ui-labelElement-label, .oo-ui-labelElement.oo-ui-labelElement-label {
+            -moz-box-sizing: border-box;
+            box-sizing: border-box
+        }
+
+        .oo-ui-labelElement-invisible {
+            display: block;
+            position: absolute;
+            clip: rect(1px, 1px, 1px, 1px);
+            width: 1px;
+            height: 1px;
+            margin: -1px;
+            border: 0;
+            padding: 0;
+            overflow: hidden
+        }
+
+        .oo-ui-labelElement .oo-ui-labelElement-label {
+            line-height: 1.42857143em
+        }
+
+        .oo-ui-labelElement .oo-ui-labelElement-label-highlight {
+            font-weight: bold
+        }
+
+        .oo-ui-iconElement-icon {
+            background-size: contain;
+            background-position: center center;
+            background-repeat: no-repeat;
+            position: absolute;
+            top: 0;
+            min-width: 20px;
+            width: 1.42857143em;
+            min-height: 20px;
+            height: 100%
+        }
+
+        .oo-ui-iconElement-noIcon {
+            display: none
+        }
+
+        .oo-ui-indicatorElement-indicator {
+            background-size: contain;
+            background-position: center center;
+            background-repeat: no-repeat;
+            position: absolute;
+            top: 0;
+            min-width: 12px;
+            width: 0.85714286em;
+            min-height: 12px;
+            height: 100%
+        }
+
+        .oo-ui-indicatorElement-noIndicator {
+            display: none
+        }
+
+        .oo-ui-pendingElement-pending {
+            background-color: #eaecf0;
+            background-image: linear-gradient(135deg, #fff 25%, transparent 25%, transparent 50%, #fff 50%, #fff 75%, transparent 75%, transparent);
+            background-size: 1.42857143em 1.42857143em;
+            -webkit-animation: oo-ui-pendingElement-stripes 650ms linear infinite;
+            animation: oo-ui-pendingElement-stripes 650ms linear infinite
+        }
+
+        @-webkit-keyframes oo-ui-pendingElement-stripes {
+            0% {
+                background-position: -1.42857143em 0
+            }
+            100% {
+                background-position: 0 0
+            }
+        }
+
+        @keyframes oo-ui-pendingElement-stripes {
+            0% {
+                background-position: -1.42857143em 0
+            }
+            100% {
+                background-position: 0 0
+            }
+        }
+
+        .oo-ui-fieldLayout {
+            display: block;
+            margin-top: 16px
+        }
+
+        .oo-ui-fieldLayout:before, .oo-ui-fieldLayout:after {
+            content: ' ';
+            display: table
+        }
+
+        .oo-ui-fieldLayout:after {
+            clear: both
+        }
+
+        .oo-ui-fieldLayout.oo-ui-fieldLayout-align-left > .oo-ui-fieldLayout-body:after, .oo-ui-fieldLayout.oo-ui-fieldLayout-align-right > .oo-ui-fieldLayout-body:after {
+            content: ' ';
+            display: block;
+            clear: both
+        }
+
+        .oo-ui-fieldLayout.oo-ui-fieldLayout-align-left > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header, .oo-ui-fieldLayout.oo-ui-fieldLayout-align-right > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header {
+            word-wrap: break-word;
+            -moz-hyphens: auto;
+            -ms-hyphens: auto;
+            hyphens: auto
+        }
+
+        .oo-ui-fieldLayout.oo-ui-fieldLayout-align-left > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header, .oo-ui-fieldLayout.oo-ui-fieldLayout-align-right > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header, .oo-ui-fieldLayout.oo-ui-fieldLayout-align-left > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-help, .oo-ui-fieldLayout.oo-ui-fieldLayout-align-right > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-help, .oo-ui-fieldLayout.oo-ui-fieldLayout-align-left > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-field, .oo-ui-fieldLayout.oo-ui-fieldLayout-align-right > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-field {
+            display: block;
+            float: left
+        }
+
+        .oo-ui-fieldLayout.oo-ui-fieldLayout-align-right > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header {
+            text-align: right
+        }
+
+        .oo-ui-fieldLayout.oo-ui-fieldLayout-align-inline {
+            word-wrap: break-word;
+            -moz-hyphens: auto;
+            -ms-hyphens: auto;
+            hyphens: auto
+        }
+
+        .oo-ui-fieldLayout.oo-ui-fieldLayout-align-inline > .oo-ui-fieldLayout-body {
+            display: table;
+            width: 100%
+        }
+
+        .oo-ui-fieldLayout.oo-ui-fieldLayout-align-inline > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header, .oo-ui-fieldLayout.oo-ui-fieldLayout-align-inline > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-field {
+            display: table-cell
+        }
+
+        .oo-ui-fieldLayout.oo-ui-fieldLayout-align-inline > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header {
+            vertical-align: middle
+        }
+
+        .oo-ui-fieldLayout.oo-ui-fieldLayout-align-inline > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-field {
+            width: 1px;
+            vertical-align: top
+        }
+
+        .oo-ui-fieldLayout.oo-ui-fieldLayout-align-top > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header, .oo-ui-fieldLayout.oo-ui-fieldLayout-align-top > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-field {
+            display: block
+        }
+
+        .oo-ui-fieldLayout .oo-ui-fieldLayout-help {
+            float: right
+        }
+
+        .oo-ui-fieldLayout .oo-ui-fieldLayout-help:not(.oo-ui-popupButtonWidget) > .oo-ui-buttonElement-button {
+            cursor: help
+        }
+
+        .oo-ui-fieldLayout.oo-ui-labelElement, .oo-ui-fieldLayout.oo-ui-fieldLayout-align-inline {
+            margin-top: 12px
+        }
+
+        .oo-ui-fieldLayout:first-child, .oo-ui-fieldLayout.oo-ui-labelElement:first-child, .oo-ui-fieldLayout.oo-ui-fieldLayout-align-inline:first-child {
+            margin-top: 0
+        }
+
+        .oo-ui-fieldLayout.oo-ui-labelElement > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header {
+            padding-bottom: 4px
+        }
+
+        .oo-ui-fieldLayout.oo-ui-labelElement.oo-ui-fieldLayout-align-top > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header, .oo-ui-fieldLayout.oo-ui-labelElement.oo-ui-fieldLayout-align-inline > .oo-ui-fieldLayout-body {
+            max-width: 50em
+        }
+
+        .oo-ui-fieldLayout.oo-ui-labelElement.oo-ui-fieldLayout-align-left > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header, .oo-ui-fieldLayout.oo-ui-labelElement.oo-ui-fieldLayout-align-right > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header {
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            width: 40%;
+            padding-right: 2.64285714em
+        }
+
+        .oo-ui-fieldLayout.oo-ui-labelElement.oo-ui-fieldLayout-align-left > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header > .oo-ui-labelElement-label, .oo-ui-fieldLayout.oo-ui-labelElement.oo-ui-fieldLayout-align-right > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header > .oo-ui-labelElement-label {
+            display: block;
+            padding-top: 4px
+        }
+
+        .oo-ui-fieldLayout.oo-ui-labelElement.oo-ui-fieldLayout-align-left > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-help, .oo-ui-fieldLayout.oo-ui-labelElement.oo-ui-fieldLayout-align-right > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-help {
+            margin-right: 0;
+            margin-left: -2.35714286em
+        }
+
+        .oo-ui-fieldLayout.oo-ui-labelElement.oo-ui-fieldLayout-align-left > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-field, .oo-ui-fieldLayout.oo-ui-labelElement.oo-ui-fieldLayout-align-right > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-field {
+            width: 60%
+        }
+
+        .oo-ui-fieldLayout.oo-ui-labelElement.oo-ui-fieldLayout-align-inline > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header {
+            padding-top: 0;
+            padding-bottom: 0;
+            padding-left: 6px
+        }
+
+        .oo-ui-fieldLayout .oo-ui-fieldLayout-help {
+            margin-right: 0
+        }
+
+        .oo-ui-fieldLayout .oo-ui-fieldLayout-help .oo-ui-buttonElement-button {
+            padding-top: 1.42857143em;
+            padding-right: 0
+        }
+
+        .oo-ui-fieldLayout .oo-ui-fieldLayout-help .oo-ui-buttonElement-button:hover, .oo-ui-fieldLayout .oo-ui-fieldLayout-help .oo-ui-buttonElement-button:active {
+            background-color: transparent
+        }
+
+        .oo-ui-fieldLayout.oo-ui-fieldLayout-align-top > .oo-ui-fieldLayout-body > .oo-ui-inline-help {
+            margin-top: 4px
+        }
+
+        .oo-ui-fieldLayout.oo-ui-fieldLayout-align-top .oo-ui-fieldLayout-help, .oo-ui-fieldLayout.oo-ui-fieldLayout-align-inline .oo-ui-fieldLayout-help {
+            margin-top: -6px;
+            margin-right: -8px;
+            margin-left: 0
+        }
+
+        .oo-ui-fieldLayout-messages {
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            max-width: 50em;
+            padding: 4px 0
+        }
+
+        .oo-ui-fieldLayout-messages > .oo-ui-messageWidget {
+            margin-left: 12px;
+            margin-right: 12px
+        }
+
+        .oo-ui-fieldLayout-messages > .oo-ui-messageWidget:first-child {
+            margin-top: 4px
+        }
+
+        .oo-ui-fieldLayout-disabled > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header > .oo-ui-labelElement-label {
+            color: #72777d
+        }
+
+        .oo-ui-actionFieldLayout-input, .oo-ui-actionFieldLayout-button {
+            display: table-cell;
+            vertical-align: middle
+        }
+
+        .oo-ui-actionFieldLayout-button {
+            width: 1%;
+            white-space: nowrap
+        }
+
+        .oo-ui-actionFieldLayout.oo-ui-fieldLayout-align-top {
+            max-width: 50em
+        }
+
+        .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-input > .oo-ui-widget {
+            margin-right: 8px
+        }
+
+        .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-input > .oo-ui-widget.oo-ui-textInputWidget > .oo-ui-inputWidget-input, .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-input > .oo-ui-widget .oo-ui-dropdownWidget-handle, .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-input > .oo-ui-widget .oo-ui-tagMultiselectWidget-handle {
+            border-radius: 2px 0 0 2px;
+            position: relative
+        }
+
+        .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-button .oo-ui-buttonElement-framed > .oo-ui-buttonElement-button {
+            border-radius: 0 2px 2px 0;
+            margin-left: -1px
+        }
+
+        .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-button .oo-ui-buttonElement-frameless {
+            margin-left: 6px
+        }
+
+        .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-input > .oo-ui-textInputWidget > .oo-ui-inputWidget-input:hover, .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-input > .oo-ui-textInputWidget > .oo-ui-inputWidget-input:focus, .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-input > .oo-ui-textInputWidget.oo-ui-flaggedElement-invalid > .oo-ui-inputWidget-input, .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-input > .oo-ui-textInputWidget > .oo-ui-inputWidget-input:hover ~ *, .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-input > .oo-ui-textInputWidget > .oo-ui-inputWidget-input:focus ~ *, .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-input > .oo-ui-textInputWidget.oo-ui-flaggedElement-invalid > .oo-ui-inputWidget-input ~ * {
+            z-index: 1
+        }
+
+        .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-button > .oo-ui-buttonElement > .oo-ui-buttonElement-button:hover, .oo-ui-actionFieldLayout .oo-ui-actionFieldLayout-button > .oo-ui-buttonElement > .oo-ui-buttonElement-button:focus {
+            z-index: 1
+        }
+
+        .oo-ui-fieldsetLayout {
+            position: relative;
+            min-width: 0;
+            margin: 0;
+            border: 0;
+            padding: 0.01px 0 0 0
+        }
+
+        body:not(:-moz-handler-blocked) .oo-ui-fieldsetLayout {
+            display: table-cell
+        }
+
+        .oo-ui-fieldsetLayout > .oo-ui-fieldsetLayout-header {
+            display: none
+        }
+
+        .oo-ui-fieldsetLayout.oo-ui-iconElement > .oo-ui-fieldsetLayout-header, .oo-ui-fieldsetLayout.oo-ui-labelElement > .oo-ui-fieldsetLayout-header {
+            color: inherit;
+            display: inline-table;
+            box-sizing: border-box;
+            padding: 0;
+            white-space: normal;
+            float: left;
+            width: 100%
+        }
+
+        .oo-ui-fieldsetLayout > .oo-ui-inline-help {
+            clear: left
+        }
+
+        .oo-ui-fieldsetLayout-group {
+            clear: both
+        }
+
+        .oo-ui-fieldsetLayout .oo-ui-fieldsetLayout-help {
+            float: right
+        }
+
+        .oo-ui-fieldsetLayout .oo-ui-fieldsetLayout-help:not(.oo-ui-popupButtonWidget) > .oo-ui-buttonElement-button {
+            cursor: help
+        }
+
+        .oo-ui-fieldsetLayout .oo-ui-fieldsetLayout-header {
+            max-width: 50em
+        }
+
+        .oo-ui-fieldsetLayout .oo-ui-fieldsetLayout-header .oo-ui-iconElement-icon {
+            height: 1.42857143em
+        }
+
+        .oo-ui-fieldsetLayout.oo-ui-iconElement > .oo-ui-fieldsetLayout-header .oo-ui-iconElement-icon {
+            display: block
+        }
+
+        .oo-ui-fieldsetLayout + .oo-ui-fieldsetLayout, .oo-ui-fieldsetLayout + .oo-ui-formLayout {
+            margin-top: 24px
+        }
+
+        .oo-ui-fieldsetLayout.oo-ui-labelElement > .oo-ui-fieldsetLayout-header > .oo-ui-labelElement-label {
+            display: inline-block;
+            margin-bottom: 8px;
+            font-size: 1.14285714em;
+            font-weight: bold
+        }
+
+        .oo-ui-fieldsetLayout.oo-ui-iconElement > .oo-ui-fieldsetLayout-header > .oo-ui-labelElement-label {
+            padding-left: 1.625em
+        }
+
+        .oo-ui-fieldsetLayout > .oo-ui-inline-help {
+            margin-bottom: 8px
+        }
+
+        .oo-ui-fieldsetLayout .oo-ui-fieldsetLayout-help, .oo-ui-fieldsetLayout .oo-ui-fieldsetLayout-help:last-child {
+            margin-right: -8px
+        }
+
+        .oo-ui-fieldsetLayout .oo-ui-fieldsetLayout-help .oo-ui-buttonElement-button {
+            padding-top: 1.42857143em;
+            padding-right: 0
+        }
+
+        .oo-ui-fieldsetLayout .oo-ui-fieldsetLayout-help .oo-ui-buttonElement-button:hover, .oo-ui-fieldsetLayout .oo-ui-fieldsetLayout-help .oo-ui-buttonElement-button:active {
+            background-color: transparent
+        }
+
+        .oo-ui-formLayout + .oo-ui-fieldsetLayout, .oo-ui-formLayout + .oo-ui-formLayout {
+            margin-top: 24px
+        }
+
+        .oo-ui-panelLayout {
+            position: relative
+        }
+
+        .oo-ui-panelLayout-scrollable {
+            overflow: auto;
+            -webkit-overflow-scrolling: touch
+        }
+
+        .oo-ui-panelLayout-expanded {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0
+        }
+
+        .oo-ui-panelLayout-padded {
+            padding: 12px 16px 16px
+        }
+
+        .oo-ui-panelLayout-padded.oo-ui-formLayout > .oo-ui-fieldsetLayout .oo-ui-labelElement-label, .oo-ui-panelLayout-padded.oo-ui-formLayout > .oo-ui-fieldsetLayout .oo-ui-iconElement-icon {
+            margin-top: -6px
+        }
+
+        .oo-ui-panelLayout-framed {
+            border: 1px solid #a2a9b1;
+            border-radius: 2px
+        }
+
+        .oo-ui-panelLayout-padded.oo-ui-panelLayout-framed {
+            margin: 12px 0
+        }
+
+        .oo-ui-horizontalLayout > .oo-ui-widget {
+            display: inline-block;
+            vertical-align: middle
+        }
+
+        .oo-ui-horizontalLayout > .oo-ui-layout {
+            display: inline-block
+        }
+
+        .oo-ui-horizontalLayout > .oo-ui-layout, .oo-ui-horizontalLayout > .oo-ui-widget {
+            margin-right: 8px
+        }
+
+        .oo-ui-horizontalLayout > .oo-ui-layout:last-child, .oo-ui-horizontalLayout > .oo-ui-widget:last-child {
+            margin-right: 0
+        }
+
+        .oo-ui-horizontalLayout > .oo-ui-layout {
+            margin-top: 0
+        }
+
+        .oo-ui-horizontalLayout > .oo-ui-widget {
+            margin-bottom: 8px
+        }
+
+        .oo-ui-optionWidget {
+            position: relative;
+            display: block
+        }
+
+        .oo-ui-optionWidget.oo-ui-widget-enabled {
+            cursor: pointer
+        }
+
+        .oo-ui-optionWidget.oo-ui-widget-disabled {
+            cursor: default
+        }
+
+        .oo-ui-optionWidget.oo-ui-labelElement > .oo-ui-labelElement-label {
+            display: block;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            overflow: hidden
+        }
+
+        .oo-ui-optionWidget-selected .oo-ui-buttonElement-button > .oo-ui-iconElement-icon {
+            opacity: 1
+        }
+
+        .oo-ui-optionWidget.oo-ui-widget-disabled {
+            color: #72777d
+        }
+
+        .oo-ui-decoratedOptionWidget {
+            padding: 6px 12px;
+            line-height: 1
+        }
+
+        .oo-ui-decoratedOptionWidget.oo-ui-iconElement {
+            padding-left: 2.64285714em
+        }
+
+        .oo-ui-decoratedOptionWidget .oo-ui-iconElement-icon {
+            left: 0.78571429em
+        }
+
+        .oo-ui-decoratedOptionWidget .oo-ui-labelElement-label {
+            line-height: 1.42857143em
+        }
+
+        .oo-ui-decoratedOptionWidget.oo-ui-indicatorElement {
+            padding-right: 2.14285714em
+        }
+
+        .oo-ui-decoratedOptionWidget .oo-ui-indicatorElement-indicator {
+            right: 12px
+        }
+
+        .oo-ui-decoratedOptionWidget.oo-ui-widget-enabled:hover .oo-ui-iconElement-icon, .oo-ui-decoratedOptionWidget.oo-ui-widget-enabled:hover .oo-ui-indicatorElement-indicator {
+            opacity: 0.74
+        }
+
+        .oo-ui-decoratedOptionWidget.oo-ui-widget-enabled .oo-ui-iconElement-icon, .oo-ui-decoratedOptionWidget.oo-ui-widget-enabled .oo-ui-indicatorElement-indicator {
+            opacity: 0.87;
+            -webkit-transition: opacity 100ms;
+            transition: opacity 100ms
+        }
+
+        .oo-ui-decoratedOptionWidget.oo-ui-widget-disabled .oo-ui-iconElement-icon, .oo-ui-decoratedOptionWidget.oo-ui-widget-disabled .oo-ui-indicatorElement-indicator {
+            opacity: 0.51
+        }
+
+        .oo-ui-radioSelectWidget:focus {
+            outline: 0
+        }
+
+        .oo-ui-radioSelectWidget:focus [type='radio']:checked + span:before {
+            border-color: #fff
+        }
+
+        .oo-ui-radioOptionWidget {
+            display: table;
+            padding: 4px 0
+        }
+
+        .oo-ui-radioOptionWidget .oo-ui-radioInputWidget, .oo-ui-radioOptionWidget.oo-ui-labelElement > .oo-ui-labelElement-label {
+            display: table-cell;
+            vertical-align: top
+        }
+
+        .oo-ui-radioOptionWidget .oo-ui-radioInputWidget {
+            width: 1px
+        }
+
+        .oo-ui-radioOptionWidget.oo-ui-labelElement > .oo-ui-labelElement-label {
+            white-space: normal
+        }
+
+        .oo-ui-radioOptionWidget:first-child {
+            padding-top: 0
+        }
+
+        .oo-ui-radioOptionWidget.oo-ui-labelElement > .oo-ui-labelElement-label {
+            padding-left: 6px
+        }
+
+        .oo-ui-radioOptionWidget .oo-ui-radioInputWidget {
+            margin-right: 0
+        }
+
+        .oo-ui-labelWidget {
+            display: inline-block
+        }
+
+        .oo-ui-labelWidget.oo-ui-inline-help {
+            display: block;
+            color: #54595d;
+            font-size: 0.92857143em
+        }
+
+        .oo-ui-messageWidget {
+            position: relative;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            font-weight: bold
+        }
+
+        .oo-ui-messageWidget > .oo-ui-labelElement-label {
+            display: block
+        }
+
+        .oo-ui-messageWidget > .oo-ui-iconElement-icon {
+            background-position: 0 0
+        }
+
+        .oo-ui-messageWidget > .oo-ui-labelElement-label {
+            margin-left: 2em
+        }
+
+        .oo-ui-messageWidget.oo-ui-messageWidget-block {
+            border: 1px solid;
+            padding: 16px 24px;
+            font-weight: normal
+        }
+
+        .oo-ui-messageWidget.oo-ui-messageWidget-block > .oo-ui-iconElement-icon {
+            background-position: 0 16px
+        }
+
+        .oo-ui-messageWidget.oo-ui-messageWidget-block.oo-ui-flaggedElement-error {
+            background-color: #fee7e6;
+            border-color: #d33
+        }
+
+        .oo-ui-messageWidget.oo-ui-messageWidget-block.oo-ui-flaggedElement-warning {
+            background-color: #fef6e7;
+            border-color: #fc3
+        }
+
+        .oo-ui-messageWidget.oo-ui-messageWidget-block.oo-ui-flaggedElement-success {
+            background-color: #d5fdf4;
+            border-color: #14866d
+        }
+
+        .oo-ui-messageWidget.oo-ui-messageWidget-block.oo-ui-flaggedElement-notice {
+            background-color: #eaecf0;
+            border-color: #a2a9b1
+        }
+
+        .oo-ui-messageWidget.oo-ui-flaggedElement-error:not(.oo-ui-messageWidget-block) {
+            color: #d33
+        }
+
+        .oo-ui-messageWidget.oo-ui-flaggedElement-success:not(.oo-ui-messageWidget-block) {
+            color: #14866d
+        }
+
+        .oo-ui-messageWidget + .oo-ui-messageWidget {
+            margin-top: 8px
+        }
+
+        .oo-ui-iconWidget {
+            vertical-align: middle;
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            clip: auto;
+            margin: 0;
+            text-indent: -9999px;
+            line-height: 2.5;
+            display: inline-block;
+            position: static;
+            top: auto;
+            height: 1.42857143em
+        }
+
+        .oo-ui-iconWidget.oo-ui-widget-disabled {
+            opacity: 0.51
+        }
+
+        .oo-ui-indicatorWidget {
+            vertical-align: middle;
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            clip: auto;
+            margin: 0;
+            text-indent: -9999px;
+            line-height: 2.5;
+            display: inline-block;
+            position: static;
+            top: auto;
+            height: 0.85714286em
+        }
+
+        .oo-ui-indicatorWidget.oo-ui-widget-disabled {
+            opacity: 0.51
+        }
+
+        .oo-ui-buttonWidget {
+            margin-right: 8px
+        }
+
+        .oo-ui-buttonWidget:last-child {
+            margin-right: 0
+        }
+
+        .oo-ui-buttonGroupWidget {
+            display: inline-block;
+            border-radius: 2px;
+            margin-right: 8px;
+            z-index: 0;
+            position: relative;
+            padding-bottom: 1px
+        }
+
+        .oo-ui-buttonGroupWidget .oo-ui-buttonWidget.oo-ui-buttonElement-active .oo-ui-buttonElement-button {
+            cursor: default
+        }
+
+        .oo-ui-buttonGroupWidget:last-child {
+            margin-right: 0
+        }
+
+        .oo-ui-buttonGroupWidget .oo-ui-buttonElement {
+            margin-right: 0;
+            z-index: 0
+        }
+
+        .oo-ui-buttonGroupWidget .oo-ui-buttonElement-framed .oo-ui-buttonElement-button {
+            margin-right: -1px;
+            margin-bottom: -1px;
+            border-radius: 0
+        }
+
+        .oo-ui-buttonGroupWidget .oo-ui-buttonElement-framed:first-child .oo-ui-buttonElement-button {
+            border-bottom-left-radius: 2px;
+            border-top-left-radius: 2px
+        }
+
+        .oo-ui-buttonGroupWidget .oo-ui-buttonElement-framed:last-child .oo-ui-buttonElement-button {
+            margin-right: 0;
+            border-bottom-right-radius: 2px;
+            border-top-right-radius: 2px
+        }
+
+        .oo-ui-buttonGroupWidget .oo-ui-buttonElement-framed.oo-ui-widget-disabled + .oo-ui-widget-disabled > .oo-ui-buttonElement-button {
+            border-left-color: #fff
+        }
+
+        .oo-ui-buttonGroupWidget.oo-ui-widget-enabled .oo-ui-buttonElement.oo-ui-widget-enabled > .oo-ui-buttonElement-button:active {
+            z-index: 1
+        }
+
+        .oo-ui-buttonGroupWidget.oo-ui-widget-enabled .oo-ui-buttonElement.oo-ui-widget-enabled > .oo-ui-buttonElement-button:focus {
+            z-index: 2
+        }
+
+        .oo-ui-buttonGroupWidget.oo-ui-widget-enabled .oo-ui-buttonElement.oo-ui-buttonElement-active > .oo-ui-buttonElement-button {
+            z-index: 3
+        }
+
+        .oo-ui-buttonGroupWidget.oo-ui-widget-enabled .oo-ui-buttonElement.oo-ui-widget-disabled > .oo-ui-buttonElement-button {
+            z-index: -1
+        }
+
+        .oo-ui-buttonGroupWidget.oo-ui-widget-enabled .oo-ui-buttonElement.oo-ui-toggleWidget-on + .oo-ui-toggleWidget-on > .oo-ui-buttonElement-button, .oo-ui-buttonGroupWidget.oo-ui-widget-enabled .oo-ui-buttonElement.oo-ui-toggleWidget-on + .oo-ui-toggleWidget-on > .oo-ui-buttonElement-button:active {
+            border-left-color: #a2a9b1;
+            z-index: 3
+        }
+
+        .oo-ui-popupWidget {
+            position: absolute;
+            z-index: 1
+        }
+
+        .oo-ui-popupWidget-popup {
+            position: relative;
+            overflow: hidden;
+            word-wrap: break-word;
+            overflow-wrap: break-word
+        }
+
+        .oo-ui-popupWidget-anchor {
+            display: none
+        }
+
+        .oo-ui-popupWidget-anchored .oo-ui-popupWidget-anchor {
+            display: block;
+            position: absolute;
+            background-repeat: no-repeat
+        }
+
+        .oo-ui-popupWidget-anchored .oo-ui-popupWidget-anchor:before, .oo-ui-popupWidget-anchored .oo-ui-popupWidget-anchor:after {
+            content: '';
+            position: absolute;
+            width: 0;
+            height: 0;
+            border-style: solid;
+            border-color: transparent
+        }
+
+        .oo-ui-popupWidget-anchored-top .oo-ui-popupWidget-anchor {
+            left: 0
+        }
+
+        .oo-ui-popupWidget-anchored-top .oo-ui-popupWidget-anchor:before, .oo-ui-popupWidget-anchored-top .oo-ui-popupWidget-anchor:after {
+            border-top: 0
+        }
+
+        .oo-ui-popupWidget-anchored-bottom .oo-ui-popupWidget-anchor {
+            left: 0
+        }
+
+        .oo-ui-popupWidget-anchored-bottom .oo-ui-popupWidget-anchor:before, .oo-ui-popupWidget-anchored-bottom .oo-ui-popupWidget-anchor:after {
+            border-bottom: 0
+        }
+
+        .oo-ui-popupWidget-anchored-start .oo-ui-popupWidget-anchor {
+            top: 0
+        }
+
+        .oo-ui-popupWidget-anchored-start .oo-ui-popupWidget-anchor:before, .oo-ui-popupWidget-anchored-start .oo-ui-popupWidget-anchor:after {
+            border-left: 0
+        }
+
+        .oo-ui-popupWidget-anchored-end .oo-ui-popupWidget-anchor {
+            top: 0
+        }
+
+        .oo-ui-popupWidget-anchored-end .oo-ui-popupWidget-anchor:before, .oo-ui-popupWidget-anchored-end .oo-ui-popupWidget-anchor:after {
+            border-right: 0
+        }
+
+        .oo-ui-popupWidget-head {
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none
+        }
+
+        .oo-ui-popupWidget-head > .oo-ui-labelElement-label {
+            cursor: default
+        }
+
+        .oo-ui-popupWidget-body {
+            clear: both
+        }
+
+        .oo-ui-popupWidget-body.oo-ui-clippableElement-clippable {
+            min-height: 1em
+        }
+
+        .oo-ui-popupWidget-popup {
+            background-color: #fff;
+            border: 1px solid #a2a9b1;
+            border-radius: 2px;
+            box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.25)
+        }
+
+        @supports (filter:drop-shadow(0 0 0)) {
+            .oo-ui-popupWidget {
+                filter: drop-shadow(0 2px 1px rgba(0, 0, 0, 0.3));
+                -webkit-transform: translateZ(0);
+                transform: translateZ(0)
+            }
+
+            .oo-ui-popupWidget-popup {
+                box-shadow: none
+            }
+        }
+
+        .oo-ui-popupWidget-anchored-top {
+            margin-top: 9px
+        }
+
+        .oo-ui-popupWidget-anchored-top .oo-ui-popupWidget-anchor {
+            top: -9px
+        }
+
+        .oo-ui-popupWidget-anchored-top .oo-ui-popupWidget-anchor:before {
+            bottom: -10px;
+            left: -9px;
+            border-bottom-color: #7b8590;
+            border-width: 10px
+        }
+
+        .oo-ui-popupWidget-anchored-top .oo-ui-popupWidget-anchor:after {
+            bottom: -10px;
+            left: -8px;
+            border-bottom-color: #fff;
+            border-width: 9px
+        }
+
+        .oo-ui-popupWidget-anchored-bottom {
+            margin-bottom: 9px
+        }
+
+        .oo-ui-popupWidget-anchored-bottom .oo-ui-popupWidget-anchor {
+            bottom: -9px
+        }
+
+        .oo-ui-popupWidget-anchored-bottom .oo-ui-popupWidget-anchor:before {
+            top: -10px;
+            left: -9px;
+            border-top-color: #a2a9b1;
+            border-width: 10px
+        }
+
+        .oo-ui-popupWidget-anchored-bottom .oo-ui-popupWidget-anchor:after {
+            top: -10px;
+            left: -8px;
+            border-top-color: #fff;
+            border-width: 9px
+        }
+
+        .oo-ui-popupWidget-anchored-start {
+            margin-left: 9px
+        }
+
+        .oo-ui-popupWidget-anchored-start .oo-ui-popupWidget-anchor {
+            left: -9px
+        }
+
+        .oo-ui-popupWidget-anchored-start .oo-ui-popupWidget-anchor:before {
+            right: -10px;
+            top: -9px;
+            border-right-color: #a2a9b1;
+            border-width: 10px
+        }
+
+        .oo-ui-popupWidget-anchored-start .oo-ui-popupWidget-anchor:after {
+            right: -10px;
+            top: -8px;
+            border-right-color: #fff;
+            border-width: 9px
+        }
+
+        .oo-ui-popupWidget-anchored-end {
+            margin-right: 9px
+        }
+
+        .oo-ui-popupWidget-anchored-end .oo-ui-popupWidget-anchor {
+            right: -9px
+        }
+
+        .oo-ui-popupWidget-anchored-end .oo-ui-popupWidget-anchor:before {
+            left: -10px;
+            top: -9px;
+            border-left-color: #a2a9b1;
+            border-width: 10px
+        }
+
+        .oo-ui-popupWidget-anchored-end .oo-ui-popupWidget-anchor:after {
+            left: -10px;
+            top: -8px;
+            border-left-color: #fff;
+            border-width: 9px
+        }
+
+        .oo-ui-popupWidget-transitioning .oo-ui-popupWidget-popup {
+            -webkit-transition: width 100ms, height 100ms, left 100ms;
+            transition: width 100ms, height 100ms, left 100ms
+        }
+
+        .oo-ui-popupWidget-head {
+            margin-bottom: 9px
+        }
+
+        .oo-ui-popupWidget-head > .oo-ui-iconElement-icon {
+            left: 0.78571429em;
+            height: calc(1.42857143em + 2 * 9px)
+        }
+
+        .oo-ui-popupWidget-head > .oo-ui-iconElement-noIcon + .oo-ui-labelElement-label {
+            margin-left: 12px
+        }
+
+        .oo-ui-popupWidget-head > .oo-ui-labelElement-label {
+            display: inline-block;
+            margin: 9px 12px 0 2.64285714em;
+            line-height: 1.42857143em
+        }
+
+        .oo-ui-popupWidget-head > .oo-ui-buttonWidget {
+            position: absolute;
+            right: 0
+        }
+
+        .oo-ui-popupWidget-head > .oo-ui-buttonWidget .oo-ui-icon-close {
+            background-size: 1.14285714em 1.14285714em
+        }
+
+        .oo-ui-popupWidget-body {
+            line-height: 1.42857143em
+        }
+
+        .oo-ui-popupWidget-body-padded {
+            margin: 5px 12px
+        }
+
+        .oo-ui-popupWidget-footer {
+            margin: 9px 12px
+        }
+
+        .oo-ui-popupButtonWidget {
+            position: relative
+        }
+
+        .oo-ui-popupButtonWidget .oo-ui-popupWidget {
+            cursor: auto
+        }
+
+        .oo-ui-inputWidget {
+            margin-right: 8px
+        }
+
+        .oo-ui-inputWidget:last-child {
+            margin-right: 0
+        }
+
+        .oo-ui-buttonInputWidget > button, .oo-ui-buttonInputWidget > input {
+            background-color: transparent;
+            margin: 0;
+            border: 0;
+            padding: 0
+        }
+
+        .oo-ui-checkboxInputWidget {
+            display: inline-block;
+            z-index: 0;
+            position: relative;
+            line-height: 1.42857143em;
+            white-space: nowrap
+        }
+
+        .oo-ui-checkboxInputWidget * {
+            font: inherit;
+            vertical-align: middle
+        }
+
+        .oo-ui-checkboxInputWidget [type='checkbox'] {
+            position: relative;
+            max-width: none;
+            width: 1.42857143em;
+            height: 1.42857143em;
+            margin: 0;
+            opacity: 0;
+            z-index: 1
+        }
+
+        .oo-ui-checkboxInputWidget [type='checkbox'] + span {
+            background-color: #fff;
+            background-size: 0 0;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            position: absolute;
+            left: 0;
+            width: 1.42857143em;
+            height: 1.42857143em;
+            border-color: #72777d;
+            border-style: solid;
+            border-radius: 2px;
+            border-width: 1px
+        }
+
+        .oo-ui-checkboxInputWidget [type='checkbox']:checked:not(:indeterminate) + span {
+            background-size: 1em 1em
+        }
+
+        .oo-ui-checkboxInputWidget [type='checkbox']:indeterminate + span:before {
+            content: ' ';
+            background-color: #fff;
+            position: absolute;
+            top: 50%;
+            left: 0.21428571em;
+            right: 0.21428571em;
+            height: 2px;
+            margin-top: -1px
+        }
+
+        .oo-ui-checkboxInputWidget [type='checkbox']:disabled + span {
+            background-color: #c8ccd1;
+            border-color: #c8ccd1
+        }
+
+        .oo-ui-checkboxInputWidget.oo-ui-widget-enabled [type='checkbox'] {
+            cursor: pointer
+        }
+
+        .oo-ui-checkboxInputWidget.oo-ui-widget-enabled [type='checkbox'] + span {
+            cursor: pointer;
+            -webkit-transition: background-color 100ms, border-color 100ms, box-shadow 100ms;
+            transition: background-color 100ms, border-color 100ms, box-shadow 100ms
+        }
+
+        .oo-ui-checkboxInputWidget.oo-ui-widget-enabled [type='checkbox']:focus + span {
+            border-color: #36c;
+            box-shadow: inset 0 0 0 1px #36c;
+            outline: 1px solid transparent
+        }
+
+        .oo-ui-checkboxInputWidget.oo-ui-widget-enabled [type='checkbox']:hover + span {
+            border-color: #447ff5
+        }
+
+        .oo-ui-checkboxInputWidget.oo-ui-widget-enabled [type='checkbox']:active + span {
+            background-color: #2a4b8d;
+            border-color: #2a4b8d;
+            box-shadow: inset 0 0 0 1px #2a4b8d
+        }
+
+        .oo-ui-checkboxInputWidget.oo-ui-widget-enabled [type='checkbox']:checked + span, .oo-ui-checkboxInputWidget.oo-ui-widget-enabled [type='checkbox']:indeterminate + span {
+            background-color: #36c;
+            border-color: #36c
+        }
+
+        .oo-ui-checkboxInputWidget.oo-ui-widget-enabled [type='checkbox']:checked:focus + span, .oo-ui-checkboxInputWidget.oo-ui-widget-enabled [type='checkbox']:indeterminate:focus + span {
+            background-color: #36c;
+            border-color: #36c;
+            box-shadow: inset 0 0 0 1px #36c, inset 0 0 0 2px #fff
+        }
+
+        .oo-ui-checkboxInputWidget.oo-ui-widget-enabled [type='checkbox']:checked:hover + span, .oo-ui-checkboxInputWidget.oo-ui-widget-enabled [type='checkbox']:indeterminate:hover + span {
+            background-color: #447ff5;
+            border-color: #447ff5
+        }
+
+        .oo-ui-checkboxInputWidget.oo-ui-widget-enabled [type='checkbox']:checked:active + span, .oo-ui-checkboxInputWidget.oo-ui-widget-enabled [type='checkbox']:indeterminate:active + span {
+            background-color: #2a4b8d;
+            border-color: #2a4b8d;
+            box-shadow: inset 0 0 0 1px #2a4b8d
+        }
+
+        .oo-ui-checkboxMultiselectInputWidget .oo-ui-fieldLayout {
+            margin-top: 0;
+            padding: 4px 0
+        }
+
+        .oo-ui-checkboxMultiselectInputWidget .oo-ui-fieldLayout:first-child {
+            padding-top: 0
+        }
+
+        .oo-ui-dropdownInputWidget {
+            position: relative;
+            vertical-align: middle;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            width: 100%;
+            max-width: 50em
+        }
+
+        .oo-ui-dropdownInputWidget .oo-ui-dropdownWidget, .oo-ui-dropdownInputWidget.oo-ui-dropdownInputWidget-php select, .oo-ui-dropdownInputWidget.oo-ui-isMobile select {
+            display: block
+        }
+
+        .oo-ui-dropdownInputWidget.oo-ui-isMobile .oo-ui-dropdownWidget {
+            display: none
+        }
+
+        .oo-ui-dropdownInputWidget select {
+            display: none;
+            background-position: -9999em 0;
+            background-repeat: no-repeat;
+            width: 100%;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box
+        }
+
+        .oo-ui-dropdownInputWidget.oo-ui-widget-enabled select {
+            cursor: pointer
+        }
+
+        .oo-ui-dropdownInputWidget select {
+            -webkit-appearance: none;
+            -moz-appearance: none;
+            background-color: transparent;
+            background-position: right 12px center;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            height: 2.28571429em;
+            border: 1px solid #a2a9b1;
+            border-radius: 2px;
+            padding-left: 12px;
+            padding-right: 2.14285714em;
+            font-size: inherit;
+            font-family: inherit;
+            vertical-align: middle;
+            background-position: -9999em 0 \9;
+            padding: 0 \9;
+        }
+
+        @media screen and (-ms-high-contrast: active),(-ms-high-contrast: none) {
+            .oo-ui-dropdownInputWidget select {
+                background-position: right 12px center;
+                padding-left: 12px;
+                padding-right: 2.14285714em
+            }
+        }
+
+        .oo-ui-dropdownInputWidget select::-ms-expand {
+            display: none
+        }
+
+        .oo-ui-dropdownInputWidget option {
+            background-color: transparent;
+            font-size: inherit;
+            font-family: inherit;
+            height: 1.5em;
+            padding: 5px 12px
+        }
+
+        .oo-ui-dropdownInputWidget.oo-ui-widget-enabled {
+            background-color: #f8f9fa;
+            -webkit-transition: background-color 100ms;
+            transition: background-color 100ms
+        }
+
+        .oo-ui-dropdownInputWidget.oo-ui-widget-enabled:hover {
+            background-color: #fff
+        }
+
+        .oo-ui-dropdownInputWidget.oo-ui-widget-enabled select {
+            color: #202122;
+            -webkit-transition: border-color 100ms, box-shadow 100ms;
+            transition: border-color 100ms, box-shadow 100ms
+        }
+
+        .oo-ui-dropdownInputWidget.oo-ui-widget-enabled select:hover {
+            color: #404244;
+            border-color: #a2a9b1
+        }
+
+        .oo-ui-dropdownInputWidget.oo-ui-widget-enabled select:active {
+            color: #000;
+            border-color: #72777d
+        }
+
+        .oo-ui-dropdownInputWidget.oo-ui-widget-enabled select:focus {
+            border-color: #36c;
+            outline: 0;
+            box-shadow: inset 0 0 0 1px #36c
+        }
+
+        .oo-ui-dropdownInputWidget.oo-ui-widget-disabled {
+            background-color: #eaecf0
+        }
+
+        .oo-ui-dropdownInputWidget.oo-ui-widget-disabled select {
+            color: #72777d;
+            border-color: #c8ccd1
+        }
+
+        .oo-ui-radioInputWidget {
+            display: inline-block;
+            z-index: 0;
+            position: relative;
+            line-height: 1.42857143em;
+            white-space: nowrap
+        }
+
+        .oo-ui-radioInputWidget * {
+            font: inherit;
+            vertical-align: middle
+        }
+
+        .oo-ui-radioInputWidget [type='radio'] {
+            position: relative;
+            max-width: none;
+            width: 1.42857143em;
+            height: 1.42857143em;
+            margin: 0;
+            opacity: 0;
+            z-index: 1
+        }
+
+        .oo-ui-radioInputWidget [type='radio'] + span {
+            background-color: #fff;
+            position: absolute;
+            left: 0;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            width: 1.42857143em;
+            height: 1.42857143em;
+            border-color: #72777d;
+            border-style: solid;
+            border-radius: 50%;
+            border-width: 0;
+            border-width: 1px
+        }
+
+        .oo-ui-radioInputWidget [type='radio'] + span:before {
+            content: ' ';
+            position: absolute;
+            top: -4px;
+            left: -4px;
+            right: -4px;
+            bottom: -4px;
+            border: 1px solid transparent;
+            border-radius: 50%
+        }
+
+        .oo-ui-radioInputWidget [type='radio']:checked + span, .oo-ui-radioInputWidget [type='radio']:checked:hover + span, .oo-ui-radioInputWidget [type='radio']:checked:focus:hover + span {
+            border-width: 6px
+        }
+
+        .oo-ui-radioInputWidget [type='radio']:disabled + span {
+            background-color: #c8ccd1;
+            border-color: #c8ccd1
+        }
+
+        .oo-ui-radioInputWidget [type='radio']:disabled:checked + span {
+            background-color: #fff
+        }
+
+        .oo-ui-radioInputWidget.oo-ui-widget-enabled [type='radio'] {
+            cursor: pointer
+        }
+
+        .oo-ui-radioInputWidget.oo-ui-widget-enabled [type='radio'] + span {
+            cursor: pointer;
+            -webkit-transition: background-color 100ms, border-color 100ms, border-width 100ms;
+            transition: background-color 100ms, border-color 100ms, border-width 100ms
+        }
+
+        .oo-ui-radioInputWidget.oo-ui-widget-enabled [type='radio']:hover + span {
+            border-color: #447ff5
+        }
+
+        .oo-ui-radioInputWidget.oo-ui-widget-enabled [type='radio']:active + span {
+            background-color: #2a4b8d;
+            border-color: #2a4b8d
+        }
+
+        .oo-ui-radioInputWidget.oo-ui-widget-enabled [type='radio']:checked + span {
+            border-color: #36c
+        }
+
+        .oo-ui-radioInputWidget.oo-ui-widget-enabled [type='radio']:checked:focus + span:before {
+            border-color: #fff
+        }
+
+        .oo-ui-radioInputWidget.oo-ui-widget-enabled [type='radio']:checked:hover + span {
+            border-color: #447ff5
+        }
+
+        .oo-ui-radioInputWidget.oo-ui-widget-enabled [type='radio']:checked:active + span {
+            border-color: #2a4b8d;
+            box-shadow: inset 0 0 0 1px #2a4b8d
+        }
+
+        .oo-ui-radioInputWidget.oo-ui-widget-enabled [type='radio']:checked:active + span:before {
+            border-color: #2a4b8d
+        }
+
+        .oo-ui-radioSelectInputWidget .oo-ui-fieldLayout {
+            margin-top: 0;
+            padding: 4px 0
+        }
+
+        .oo-ui-radioSelectInputWidget .oo-ui-fieldLayout:first-child {
+            padding-top: 0
+        }
+
+        .oo-ui-textInputWidget {
+            position: relative;
+            vertical-align: middle;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            width: 100%;
+            max-width: 50em
+        }
+
+        .oo-ui-textInputWidget .oo-ui-inputWidget-input {
+            -webkit-appearance: none;
+            -moz-appearance: textfield;
+            display: block;
+            width: 100%;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box
+        }
+
+        .oo-ui-textInputWidget input::-ms-clear {
+            display: none
+        }
+
+        .oo-ui-textInputWidget textarea {
+            overflow: auto
+        }
+
+        .oo-ui-textInputWidget textarea.oo-ui-textInputWidget-autosized {
+            resize: none
+        }
+
+        .oo-ui-textInputWidget [type='number']::-webkit-outer-spin-button, .oo-ui-textInputWidget [type='number']::-webkit-inner-spin-button {
+            -webkit-appearance: none;
+            margin: 0
+        }
+
+        .oo-ui-textInputWidget [type='search']::-webkit-search-decoration, .oo-ui-textInputWidget [type='search']::-webkit-search-cancel-button {
+            display: none
+        }
+
+        .oo-ui-textInputWidget > .oo-ui-iconElement-icon, .oo-ui-textInputWidget-labelPosition-before > .oo-ui-labelElement-label {
+            left: 0
+        }
+
+        .oo-ui-textInputWidget > .oo-ui-indicatorElement-indicator, .oo-ui-textInputWidget-labelPosition-after > .oo-ui-labelElement-label {
+            right: 0
+        }
+
+        .oo-ui-textInputWidget > .oo-ui-labelElement-label {
+            position: absolute;
+            top: 0
+        }
+
+        .oo-ui-textInputWidget.oo-ui-labelElement > .oo-ui-labelElement-label {
+            display: block
+        }
+
+        .oo-ui-textInputWidget-labelPosition-after.oo-ui-labelElement ::-ms-clear {
+            display: none
+        }
+
+        .oo-ui-textInputWidget-php > .oo-ui-iconElement-icon, .oo-ui-textInputWidget-php > .oo-ui-indicatorElement-indicator, .oo-ui-textInputWidget-php > .oo-ui-labelElement-label {
+            pointer-events: none
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled > .oo-ui-iconElement-icon, .oo-ui-textInputWidget.oo-ui-widget-enabled > .oo-ui-indicatorElement-indicator {
+            cursor: text
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled.oo-ui-textInputWidget-type-search > .oo-ui-indicatorElement-indicator {
+            cursor: pointer
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-disabled > * {
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none
+        }
+
+        .oo-ui-textInputWidget .oo-ui-inputWidget-input {
+            background-color: #fff;
+            color: #000;
+            margin: 0;
+            border: 1px solid #a2a9b1;
+            border-radius: 2px;
+            padding: 5px 8px;
+            font-size: inherit;
+            font-family: inherit;
+            line-height: 1.42857143em
+        }
+
+        .oo-ui-textInputWidget input {
+            height: 2.28571429em
+        }
+
+        .oo-ui-textInputWidget .oo-ui-pendingElement-pending {
+            background-color: #eaecf0
+        }
+
+        .oo-ui-textInputWidget.oo-ui-iconElement .oo-ui-inputWidget-input {
+            padding-left: 2.42857143em
+        }
+
+        .oo-ui-textInputWidget.oo-ui-iconElement > .oo-ui-iconElement-icon {
+            left: 9px
+        }
+
+        .oo-ui-textInputWidget.oo-ui-iconElement textarea + .oo-ui-iconElement-icon {
+            max-height: 2.28571429em
+        }
+
+        .oo-ui-textInputWidget > .oo-ui-labelElement-label {
+            color: #72777d;
+            padding: 0 12px 0 8px;
+            line-height: 2.28571429em
+        }
+
+        .oo-ui-textInputWidget.oo-ui-indicatorElement .oo-ui-inputWidget-input {
+            padding-right: 28px
+        }
+
+        .oo-ui-textInputWidget.oo-ui-indicatorElement.oo-ui-textInputWidget-labelPosition-after > .oo-ui-labelElement-label {
+            padding-right: 0
+        }
+
+        .oo-ui-textInputWidget.oo-ui-indicatorElement > .oo-ui-indicatorElement-indicator {
+            max-height: 2.28571429em;
+            margin-right: 0.71428571em
+        }
+
+        .oo-ui-textInputWidget-labelPosition-after.oo-ui-indicatorElement > .oo-ui-labelElement-label {
+            margin-right: 2.28571429em
+        }
+
+        .oo-ui-textInputWidget-labelPosition-before.oo-ui-iconElement > .oo-ui-labelElement-label {
+            padding-left: 2.42857143em
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled .oo-ui-inputWidget-input {
+            box-shadow: inset 0 0 0 1px transparent;
+            -webkit-transition: border-color 250ms, box-shadow 250ms;
+            transition: border-color 250ms, box-shadow 250ms
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled .oo-ui-inputWidget-input::-webkit-input-placeholder {
+            color: #72777d;
+            opacity: 1
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled .oo-ui-inputWidget-input:-ms-input-placeholder {
+            color: #72777d;
+            opacity: 1
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled .oo-ui-inputWidget-input::-moz-placeholder {
+            color: #72777d;
+            opacity: 1
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled .oo-ui-inputWidget-input::placeholder {
+            color: #72777d;
+            opacity: 1
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled .oo-ui-inputWidget-input:focus {
+            outline: 0;
+            border-color: #36c;
+            box-shadow: inset 0 0 0 1px #36c
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled .oo-ui-inputWidget-input:focus ~ .oo-ui-iconElement-icon, .oo-ui-textInputWidget.oo-ui-widget-enabled .oo-ui-inputWidget-input:focus ~ .oo-ui-indicatorElement-indicator {
+            opacity: 1
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled .oo-ui-inputWidget-input[readonly]:not(.oo-ui-pendingElement-pending) {
+            background-color: #f8f9fa
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled:hover .oo-ui-inputWidget-input {
+            border-color: #72777d
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled:hover .oo-ui-inputWidget-input:focus {
+            border-color: #36c
+        }
+
+        @media screen and (min-width: 0) {
+            .oo-ui-textInputWidget.oo-ui-widget-enabled textarea.oo-ui-inputWidget-input:focus {
+                outline: 1px solid #36c;
+                outline-offset: -2px
+            }
+
+            .oo-ui-textInputWidget.oo-ui-widget-enabled.oo-ui-flaggedElement-invalid textarea.oo-ui-inputWidget-input:focus {
+                outline-color: #d33
+            }
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled > .oo-ui-iconElement-icon {
+            opacity: 0.67
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled > .oo-ui-indicatorElement-indicator {
+            opacity: 0.87
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled.oo-ui-flaggedElement-invalid .oo-ui-inputWidget-input {
+            border-color: #d33
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled.oo-ui-flaggedElement-invalid .oo-ui-inputWidget-input:hover {
+            border-color: #d33
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-enabled.oo-ui-flaggedElement-invalid .oo-ui-inputWidget-input:focus {
+            border-color: #d33;
+            box-shadow: inset 0 0 0 1px #d33
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-disabled .oo-ui-inputWidget-input {
+            background-color: #eaecf0;
+            -webkit-text-fill-color: #72777d;
+            color: #72777d;
+            text-shadow: 0 1px 1px #fff;
+            border-color: #c8ccd1
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-disabled > .oo-ui-iconElement-icon, .oo-ui-textInputWidget.oo-ui-widget-disabled > .oo-ui-indicatorElement-indicator {
+            opacity: 0.51
+        }
+
+        .oo-ui-textInputWidget.oo-ui-widget-disabled > .oo-ui-labelElement-label {
+            color: #72777d;
+            text-shadow: 0 1px 1px #fff
+        }
+
+        .oo-ui-menuSelectWidget {
+            position: absolute;
+            width: 100%;
+            z-index: 4;
+            background-color: #fff;
+            margin-top: -1px;
+            margin-bottom: -1px;
+            border: 1px solid #a2a9b1;
+            border-radius: 0 0 2px 2px;
+            box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.25)
+        }
+
+        .oo-ui-menuSelectWidget.oo-ui-clippableElement-clippable {
+            min-height: 32px
+        }
+
+        .oo-ui-menuSelectWidget-invisible {
+            display: none
+        }
+
+        .oo-ui-menuOptionWidget {
+            -webkit-transition: background-color 100ms, color 100ms;
+            transition: background-color 100ms, color 100ms
+        }
+
+        .oo-ui-menuOptionWidget-checkIcon {
+            display: none
+        }
+
+        .oo-ui-menuOptionWidget.oo-ui-optionWidget-highlighted {
+            background-color: #eaecf0;
+            color: #000
+        }
+
+        .oo-ui-menuOptionWidget.oo-ui-optionWidget-selected {
+            background-color: #eaf3ff;
+            color: #36c
+        }
+
+        .oo-ui-menuOptionWidget.oo-ui-optionWidget-selected.oo-ui-menuOptionWidget.oo-ui-optionWidget-highlighted, .oo-ui-menuOptionWidget.oo-ui-optionWidget-pressed.oo-ui-menuOptionWidget.oo-ui-optionWidget-highlighted {
+            background-color: rgba(41, 98, 204, 0.1);
+            color: #36c
+        }
+
+        .oo-ui-menuOptionWidget.oo-ui-widget-enabled.oo-ui-optionWidget {
+            color: #202122
+        }
+
+        .oo-ui-menuSectionOptionWidget {
+            color: #72777d;
+            padding: 5px 12px 4px;
+            font-weight: bold
+        }
+
+        .oo-ui-menuSectionOptionWidget.oo-ui-widget-enabled {
+            cursor: default
+        }
+
+        .oo-ui-menuSectionOptionWidget ~ .oo-ui-menuOptionWidget {
+            padding-left: 24px
+        }
+
+        .oo-ui-menuSectionOptionWidget ~ .oo-ui-menuOptionWidget.oo-ui-iconElement {
+            padding-left: 3.5em
+        }
+
+        .oo-ui-menuSectionOptionWidget ~ .oo-ui-menuOptionWidget.oo-ui-iconElement .oo-ui-iconElement-icon {
+            left: 1.71428571em
+        }
+
+        .oo-ui-dropdownWidget {
+            display: inline-block;
+            position: relative;
+            vertical-align: middle;
+            width: 100%;
+            max-width: 50em;
+            margin-right: 8px
+        }
+
+        .oo-ui-dropdownWidget-handle {
+            position: relative;
+            width: 100%;
+            display: block;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            cursor: default;
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box
+        }
+
+        .oo-ui-dropdownWidget-handle .oo-ui-labelElement-label {
+            display: inline-block
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-widget-enabled .oo-ui-dropdownWidget-handle {
+            cursor: pointer
+        }
+
+        .oo-ui-dropdownWidget:last-child {
+            margin-right: 0
+        }
+
+        .oo-ui-dropdownWidget-handle {
+            min-height: 32px;
+            border: 1px solid #a2a9b1;
+            border-radius: 2px;
+            padding: 5px 2.14285714em 5px 12px;
+            line-height: 1
+        }
+
+        .oo-ui-dropdownWidget-handle .oo-ui-iconElement-icon {
+            left: 12px
+        }
+
+        .oo-ui-dropdownWidget-handle .oo-ui-indicatorElement-indicator {
+            right: 11px
+        }
+
+        .oo-ui-dropdownWidget-handle .oo-ui-labelElement-label {
+            line-height: 1.42857143em
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-iconElement .oo-ui-dropdownWidget-handle {
+            padding-left: 2.71428571em
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-indicatorElement .oo-ui-dropdownWidget-handle {
+            padding-right: 2.57142857em
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-widget-enabled .oo-ui-dropdownWidget-handle {
+            background-color: #f8f9fa;
+            color: #202122;
+            -webkit-transition: background-color 100ms, border-color 100ms, box-shadow 100ms;
+            transition: background-color 100ms, border-color 100ms, box-shadow 100ms
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-widget-enabled .oo-ui-dropdownWidget-handle:hover {
+            background-color: #fff;
+            color: #404244;
+            border-color: #a2a9b1
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-widget-enabled .oo-ui-dropdownWidget-handle:hover .oo-ui-iconElement-icon, .oo-ui-dropdownWidget.oo-ui-widget-enabled .oo-ui-dropdownWidget-handle:hover .oo-ui-indicatorElement-indicator {
+            opacity: 0.74
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-widget-enabled .oo-ui-dropdownWidget-handle:active {
+            color: #000;
+            border-color: #72777d
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-widget-enabled .oo-ui-dropdownWidget-handle:focus {
+            border-color: #36c;
+            outline: 0;
+            box-shadow: inset 0 0 0 1px #36c
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-widget-enabled .oo-ui-dropdownWidget-handle .oo-ui-iconElement-icon, .oo-ui-dropdownWidget.oo-ui-widget-enabled .oo-ui-dropdownWidget-handle .oo-ui-indicatorElement-indicator {
+            opacity: 0.87;
+            -webkit-transition: opacity 100ms;
+            transition: opacity 100ms
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-widget-enabled.oo-ui-dropdownWidget-open .oo-ui-dropdownWidget-handle {
+            background-color: #fff
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-widget-enabled.oo-ui-dropdownWidget-open .oo-ui-dropdownWidget-handle .oo-ui-iconElement-icon, .oo-ui-dropdownWidget.oo-ui-widget-enabled.oo-ui-dropdownWidget-open .oo-ui-dropdownWidget-handle .oo-ui-indicatorElement-indicator {
+            opacity: 1
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-widget-disabled .oo-ui-dropdownWidget-handle {
+            color: #72777d;
+            text-shadow: 0 1px 1px #fff;
+            border-color: #c8ccd1;
+            background-color: #eaecf0
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-widget-disabled .oo-ui-dropdownWidget-handle:focus {
+            outline: 0
+        }
+
+        .oo-ui-dropdownWidget.oo-ui-widget-disabled .oo-ui-dropdownWidget-handle .oo-ui-indicatorElement-indicator {
+            opacity: 0.15
+        }
+
+        .oo-ui-comboBoxInputWidget {
+            display: inline-block;
+            position: relative
+        }
+
+        .oo-ui-comboBoxInputWidget-field {
+            display: table;
+            width: 100%;
+            table-layout: fixed
+        }
+
+        .oo-ui-comboBoxInputWidget .oo-ui-inputWidget-input {
+            display: table-cell;
+            vertical-align: middle;
+            position: relative;
+            overflow: hidden
+        }
+
+        .oo-ui-comboBoxInputWidget-dropdownButton {
+            display: table-cell
+        }
+
+        .oo-ui-comboBoxInputWidget-dropdownButton > .oo-ui-buttonElement-button {
+            display: block;
+            overflow: hidden
+        }
+
+        .oo-ui-comboBoxInputWidget.oo-ui-comboBoxInputWidget-empty .oo-ui-comboBoxInputWidget-dropdownButton {
+            display: none
+        }
+
+        .oo-ui-comboBoxInputWidget-php ::-webkit-calendar-picker-indicator {
+            opacity: 0;
+            position: absolute;
+            right: 0;
+            top: 0;
+            width: 2.5em;
+            height: 2.5em;
+            padding: 0
+        }
+
+        .oo-ui-comboBoxInputWidget-php > .oo-ui-indicatorWidget {
+            display: block;
+            position: absolute;
+            top: 0;
+            height: 100%;
+            pointer-events: none
+        }
+
+        .oo-ui-comboBoxInputWidget .oo-ui-inputWidget-input {
+            height: 2.28571429em;
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+            border-right-width: 0
+        }
+
+        .oo-ui-comboBoxInputWidget.oo-ui-comboBoxInputWidget-empty .oo-ui-inputWidget-input, .oo-ui-comboBoxInputWidget-php .oo-ui-inputWidget-input {
+            border-top-right-radius: 2px;
+            border-bottom-right-radius: 2px;
+            border-right-width: 1px
+        }
+
+        .oo-ui-comboBoxInputWidget-dropdownButton.oo-ui-indicatorElement {
+            width: 2.64285714em
+        }
+
+        .oo-ui-comboBoxInputWidget-dropdownButton.oo-ui-indicatorElement .oo-ui-buttonElement-button {
+            min-width: 37px;
+            padding-left: 0
+        }
+
+        .oo-ui-comboBoxInputWidget-dropdownButton.oo-ui-indicatorElement .oo-ui-buttonElement-button > .oo-ui-indicatorElement-indicator {
+            right: 0.85714286em
+        }
+
+        .oo-ui-comboBoxInputWidget-dropdownButton.oo-ui-indicatorElement .oo-ui-buttonElement-button, .oo-ui-comboBoxInputWidget-dropdownButton.oo-ui-indicatorElement .oo-ui-buttonElement-button:focus {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0
+        }
+
+        .oo-ui-comboBoxInputWidget-php .oo-ui-indicatorWidget {
+            right: 12px;
+            margin: 0
+        }
+
+        .oo-ui-comboBoxInputWidget-open .oo-ui-comboBoxInputWidget-dropdownButton > .oo-ui-buttonElement-button {
+            background-color: #fff
+        }
+
+        .oo-ui-comboBoxInputWidget-open .oo-ui-comboBoxInputWidget-dropdownButton > .oo-ui-buttonElement-button .oo-ui-indicatorElement-indicator {
+            opacity: 1
+        }
+
+        .oo-ui-comboBoxInputWidget.oo-ui-widget-disabled .oo-ui-indicatorElement-indicator {
+            opacity: 1
+        }
+
+        .oo-ui-multioptionWidget {
+            position: relative;
+            display: block
+        }
+
+        .oo-ui-multioptionWidget.oo-ui-widget-enabled {
+            cursor: pointer
+        }
+
+        .oo-ui-multioptionWidget.oo-ui-widget-disabled {
+            cursor: default
+        }
+
+        .oo-ui-multioptionWidget.oo-ui-labelElement .oo-ui-labelElement-label {
+            display: block;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            overflow: hidden
+        }
+
+        .oo-ui-multioptionWidget.oo-ui-widget-disabled {
+            color: #72777d
+        }
+
+        .oo-ui-checkboxMultioptionWidget {
+            display: table;
+            padding: 4px 0
+        }
+
+        .oo-ui-checkboxMultioptionWidget .oo-ui-checkboxInputWidget, .oo-ui-checkboxMultioptionWidget.oo-ui-labelElement > .oo-ui-labelElement-label {
+            display: table-cell;
+            vertical-align: top
+        }
+
+        .oo-ui-checkboxMultioptionWidget .oo-ui-checkboxInputWidget {
+            width: 1px
+        }
+
+        .oo-ui-checkboxMultioptionWidget.oo-ui-labelElement > .oo-ui-labelElement-label {
+            white-space: normal
+        }
+
+        .oo-ui-checkboxMultioptionWidget:first-child {
+            padding-top: 0
+        }
+
+        .oo-ui-checkboxMultioptionWidget.oo-ui-labelElement > .oo-ui-labelElement-label {
+            padding-left: 6px
+        }
+
+        .oo-ui-checkboxMultioptionWidget .oo-ui-checkboxInputWidget {
+            margin-right: 0
+        }
+
+        .oo-ui-progressBarWidget {
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+            max-width: 50em;
+            border: 1px solid #a2a9b1;
+            border-radius: 1em;
+            box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15);
+            overflow: hidden
+        }
+
+        .oo-ui-progressBarWidget:not(.oo-ui-pendingElement-pending) {
+            background-color: #fff
+        }
+
+        .oo-ui-progressBarWidget-bar {
+            height: 1em;
+            -webkit-transition: width 100ms;
+            transition: width 100ms
+        }
+
+        .oo-ui-progressBarWidget-indeterminate .oo-ui-progressBarWidget-bar {
+            -webkit-animation: oo-ui-progressBarWidget-slide 2s infinite linear;
+            animation: oo-ui-progressBarWidget-slide 2s infinite linear;
+            width: 40%;
+            -webkit-transform: translate(-25%);
+            -ms-transform: translate(-25%);
+            transform: translate(-25%)
+        }
+
+        .oo-ui-progressBarWidget.oo-ui-widget-enabled .oo-ui-progressBarWidget-bar {
+            background-color: #36c
+        }
+
+        .oo-ui-progressBarWidget.oo-ui-widget-disabled .oo-ui-progressBarWidget-bar {
+            background-color: #c8ccd1
+        }
+
+        @-webkit-keyframes oo-ui-progressBarWidget-slide {
+            from {
+                -webkit-transform: translate(-100%);
+                -ms-transform: translate(-100%);
+                transform: translate(-100%)
+            }
+            to {
+                -webkit-transform: translate(350%);
+                -ms-transform: translate(350%);
+                transform: translate(350%)
+            }
+        }
+
+        @keyframes oo-ui-progressBarWidget-slide {
+            from {
+                -webkit-transform: translate(-100%);
+                -ms-transform: translate(-100%);
+                transform: translate(-100%)
+            }
+            to {
+                -webkit-transform: translate(350%);
+                -ms-transform: translate(350%);
+                transform: translate(350%)
+            }
+        }
+
+        .oo-ui-numberInputWidget {
+            display: inline-block;
+            position: relative;
+            max-width: 50em
+        }
+
+        .oo-ui-numberInputWidget-buttoned .oo-ui-buttonWidget, .oo-ui-numberInputWidget-buttoned .oo-ui-inputWidget-input {
+            display: table-cell;
+            height: 100%
+        }
+
+        .oo-ui-numberInputWidget-field {
+            display: table;
+            table-layout: fixed;
+            width: 100%
+        }
+
+        .oo-ui-numberInputWidget-buttoned .oo-ui-buttonWidget {
+            width: 2.64285714em
+        }
+
+        .oo-ui-numberInputWidget-buttoned .oo-ui-buttonWidget .oo-ui-buttonElement-button {
+            display: block;
+            min-width: 37px;
+            min-height: 32px;
+            padding-left: 0;
+            padding-right: 0
+        }
+
+        .oo-ui-numberInputWidget-buttoned .oo-ui-inputWidget-input {
+            height: 2.28571429em;
+            border-radius: 0
+        }
+
+        .oo-ui-numberInputWidget-minusButton > .oo-ui-buttonElement-button {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+            border-right-width: 0
+        }
+
+        .oo-ui-numberInputWidget-plusButton > .oo-ui-buttonElement-button {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+            border-left-width: 0
+        }
+
+        .oo-ui-numberInputWidget.oo-ui-widget-disabled.oo-ui-numberInputWidget-buttoned .oo-ui-iconElement-icon {
+            opacity: 1
+        }
+
+        .oo-ui-selectFileInputWidget {
+            width: 100%;
+            max-width: 50em;
+            min-height: 2.28571429em
+        }
+
+        .oo-ui-selectFileInputWidget-selectButton > .oo-ui-buttonElement-button {
+            position: relative;
+            overflow: hidden
+        }
+
+        .oo-ui-selectFileInputWidget-selectButton > .oo-ui-buttonElement-button > [type='file'] {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            width: 100%;
+            height: 100%;
+            opacity: 0;
+            z-index: 1;
+            cursor: pointer;
+            padding-top: 100px
+        }
+
+        .oo-ui-selectFileInputWidget-selectButton.oo-ui-widget-disabled > .oo-ui-buttonElement-button > [type='file'] {
+            display: none
+        }
+
+        .oo-ui-selectFileInputWidget-info > .oo-ui-inputWidget-input {
+            pointer-events: none
+        }
+
+        .oo-ui-selectFileInputWidget-empty.oo-ui-widget-enabled .oo-ui-selectFileInputWidget-label {
+            cursor: default
+        }
+
+        .oo-ui-selectFileInputWidget-info > .oo-ui-inputWidget-input {
+            height: 2.28571429em
+        }
+
+        .oo-ui-defaultOverlay {
+            position: absolute;
+            top: 0;
+            left: 0
+        }
+
+        .oo-ui-defaultOverlay, .skin-vector .oo-ui-windowManager-modal > .oo-ui-dialog, .skin-vector .ve-ui-overlay-global {
+            z-index: 101
+        }
+
+        body > .oo-ui-windowManager, .oo-ui-defaultOverlay {
+            font-size: 0.875em
+        }
+
+        .oo-ui-icon-alert, .mw-ui-icon-alert:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=alert&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Ealert%3C/title%3E%3Cpath d=%22M11.53 2.3A1.85 1.85 0 0010 1.21 1.85 1.85 0 008.48 2.3L.36 16.36C-.48 17.81.21 19 1.88 19h16.24c1.67 0 2.36-1.19 1.52-2.64zM11 16H9v-2h2zm0-4H9V6h2z%22/%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-invert.oo-ui-icon-alert, .mw-ui-icon-alert-invert:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=alert&variant=invert&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Ealert%3C/title%3E%3Cg fill=%22%23fff%22%3E%3Cpath d=%22M11.53 2.3A1.85 1.85 0 0010 1.21 1.85 1.85 0 008.48 2.3L.36 16.36C-.48 17.81.21 19 1.88 19h16.24c1.67 0 2.36-1.19 1.52-2.64zM11 16H9v-2h2zm0-4H9V6h2z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-progressive.oo-ui-icon-alert, .mw-ui-icon-alert-progressive:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=alert&variant=progressive&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Ealert%3C/title%3E%3Cg fill=%22%2336c%22%3E%3Cpath d=%22M11.53 2.3A1.85 1.85 0 0010 1.21 1.85 1.85 0 008.48 2.3L.36 16.36C-.48 17.81.21 19 1.88 19h16.24c1.67 0 2.36-1.19 1.52-2.64zM11 16H9v-2h2zm0-4H9V6h2z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-warning.oo-ui-icon-alert, .mw-ui-icon-alert-warning:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=alert&variant=warning&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Ealert%3C/title%3E%3Cg fill=%22%23fc3%22%3E%3Cpath d=%22M11.53 2.3A1.85 1.85 0 0010 1.21 1.85 1.85 0 008.48 2.3L.36 16.36C-.48 17.81.21 19 1.88 19h16.24c1.67 0 2.36-1.19 1.52-2.64zM11 16H9v-2h2zm0-4H9V6h2z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-icon-error, .mw-ui-icon-error:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=error&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Eerror%3C/title%3E%3Cpath d=%22M13.728 1H6.272L1 6.272v7.456L6.272 19h7.456L19 13.728V6.272zM11 15H9v-2h2zm0-4H9V5h2z%22/%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-invert.oo-ui-icon-error, .mw-ui-icon-error-invert:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=error&variant=invert&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Eerror%3C/title%3E%3Cg fill=%22%23fff%22%3E%3Cpath d=%22M13.728 1H6.272L1 6.272v7.456L6.272 19h7.456L19 13.728V6.272zM11 15H9v-2h2zm0-4H9V5h2z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-progressive.oo-ui-icon-error, .mw-ui-icon-error-progressive:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=error&variant=progressive&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Eerror%3C/title%3E%3Cg fill=%22%2336c%22%3E%3Cpath d=%22M13.728 1H6.272L1 6.272v7.456L6.272 19h7.456L19 13.728V6.272zM11 15H9v-2h2zm0-4H9V5h2z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-error.oo-ui-icon-error, .mw-ui-icon-error-error:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=error&variant=error&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Eerror%3C/title%3E%3Cg fill=%22%23d33%22%3E%3Cpath d=%22M13.728 1H6.272L1 6.272v7.456L6.272 19h7.456L19 13.728V6.272zM11 15H9v-2h2zm0-4H9V5h2z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-icon-info, .mw-ui-icon-info:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=info&format=rasterized&lang=en&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Einfo%3C/title%3E%3Cpath d=%22M9.5 16A6.61 6.61 0 013 9.5 6.61 6.61 0 019.5 3 6.61 6.61 0 0116 9.5 6.63 6.63 0 019.5 16zm0-14A7.5 7.5 0 1017 9.5 7.5 7.5 0 009.5 2zm.5 6v4.08h1V13H8.07v-.92H9V9H8V8zM9 6h1v1H9z%22/%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-invert.oo-ui-icon-info, .mw-ui-icon-info-invert:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=info&variant=invert&format=rasterized&lang=en&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Einfo%3C/title%3E%3Cg fill=%22%23fff%22%3E%3Cpath d=%22M9.5 16A6.61 6.61 0 013 9.5 6.61 6.61 0 019.5 3 6.61 6.61 0 0116 9.5 6.63 6.63 0 019.5 16zm0-14A7.5 7.5 0 1017 9.5 7.5 7.5 0 009.5 2zm.5 6v4.08h1V13H8.07v-.92H9V9H8V8zM9 6h1v1H9z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-progressive.oo-ui-icon-info, .mw-ui-icon-info-progressive:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=info&variant=progressive&format=rasterized&lang=en&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Einfo%3C/title%3E%3Cg fill=%22%2336c%22%3E%3Cpath d=%22M9.5 16A6.61 6.61 0 013 9.5 6.61 6.61 0 019.5 3 6.61 6.61 0 0116 9.5 6.63 6.63 0 019.5 16zm0-14A7.5 7.5 0 1017 9.5 7.5 7.5 0 009.5 2zm.5 6v4.08h1V13H8.07v-.92H9V9H8V8zM9 6h1v1H9z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-icon-infoFilled, .mw-ui-icon-infoFilled:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=infoFilled&format=rasterized&lang=en&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Einfo%3C/title%3E%3Cpath d=%22M10 0C4.477 0 0 4.477 0 10s4.477 10 10 10 10-4.477 10-10S15.523 0 10 0zM9 5h2v2H9zm0 4h2v6H9z%22/%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-invert.oo-ui-icon-infoFilled, .mw-ui-icon-infoFilled-invert:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=infoFilled&variant=invert&format=rasterized&lang=en&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Einfo%3C/title%3E%3Cg fill=%22%23fff%22%3E%3Cpath d=%22M10 0C4.477 0 0 4.477 0 10s4.477 10 10 10 10-4.477 10-10S15.523 0 10 0zM9 5h2v2H9zm0 4h2v6H9z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-progressive.oo-ui-icon-infoFilled, .mw-ui-icon-infoFilled-progressive:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=infoFilled&variant=progressive&format=rasterized&lang=en&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Einfo%3C/title%3E%3Cg fill=%22%2336c%22%3E%3Cpath d=%22M10 0C4.477 0 0 4.477 0 10s4.477 10 10 10 10-4.477 10-10S15.523 0 10 0zM9 5h2v2H9zm0 4h2v6H9z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-icon-add, .mw-ui-icon-add:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=add&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Eadd%3C/title%3E%3Cpath d=%22M11 9V4H9v5H4v2h5v5h2v-5h5V9z%22/%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-invert.oo-ui-icon-add, .mw-ui-icon-add-invert:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=add&variant=invert&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Eadd%3C/title%3E%3Cg fill=%22%23fff%22%3E%3Cpath d=%22M11 9V4H9v5H4v2h5v5h2v-5h5V9z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-progressive.oo-ui-icon-add, .mw-ui-icon-add-progressive:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=add&variant=progressive&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Eadd%3C/title%3E%3Cg fill=%22%2336c%22%3E%3Cpath d=%22M11 9V4H9v5H4v2h5v5h2v-5h5V9z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-icon-check, .mw-ui-icon-check:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=check&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Echeck%3C/title%3E%3Cpath d=%22M7 14.17L2.83 10l-1.41 1.41L7 17 19 5l-1.41-1.42z%22/%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-invert.oo-ui-icon-check, .mw-ui-icon-check-invert:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=check&variant=invert&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Echeck%3C/title%3E%3Cg fill=%22%23fff%22%3E%3Cpath d=%22M7 14.17L2.83 10l-1.41 1.41L7 17 19 5l-1.41-1.42z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-progressive.oo-ui-icon-check, .mw-ui-icon-check-progressive:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=check&variant=progressive&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Echeck%3C/title%3E%3Cg fill=%22%2336c%22%3E%3Cpath d=%22M7 14.17L2.83 10l-1.41 1.41L7 17 19 5l-1.41-1.42z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-destructive.oo-ui-icon-check, .mw-ui-icon-check-destructive:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=check&variant=destructive&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Echeck%3C/title%3E%3Cg fill=%22%23d33%22%3E%3Cpath d=%22M7 14.17L2.83 10l-1.41 1.41L7 17 19 5l-1.41-1.42z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-success.oo-ui-icon-check, .mw-ui-icon-check-success:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=check&variant=success&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Echeck%3C/title%3E%3Cg fill=%22%2314866d%22%3E%3Cpath d=%22M7 14.17L2.83 10l-1.41 1.41L7 17 19 5l-1.41-1.42z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-icon-close, .mw-ui-icon-close:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=close&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Eclose%3C/title%3E%3Cpath d=%22M4.34 2.93l12.73 12.73-1.41 1.41L2.93 4.35z%22/%3E%3Cpath d=%22M17.07 4.34L4.34 17.07l-1.41-1.41L15.66 2.93z%22/%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-invert.oo-ui-icon-close, .mw-ui-icon-close-invert:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=close&variant=invert&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Eclose%3C/title%3E%3Cg fill=%22%23fff%22%3E%3Cpath d=%22M4.34 2.93l12.73 12.73-1.41 1.41L2.93 4.35z%22/%3E%3Cpath d=%22M17.07 4.34L4.34 17.07l-1.41-1.41L15.66 2.93z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-progressive.oo-ui-icon-close, .mw-ui-icon-close-progressive:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=close&variant=progressive&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Eclose%3C/title%3E%3Cg fill=%22%2336c%22%3E%3Cpath d=%22M4.34 2.93l12.73 12.73-1.41 1.41L2.93 4.35z%22/%3E%3Cpath d=%22M17.07 4.34L4.34 17.07l-1.41-1.41L15.66 2.93z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-destructive.oo-ui-icon-close, .mw-ui-icon-close-destructive:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=close&variant=destructive&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Eclose%3C/title%3E%3Cg fill=%22%23d33%22%3E%3Cpath d=%22M4.34 2.93l12.73 12.73-1.41 1.41L2.93 4.35z%22/%3E%3Cpath d=%22M17.07 4.34L4.34 17.07l-1.41-1.41L15.66 2.93z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-icon-search, .mw-ui-icon-search:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=search&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Esearch%3C/title%3E%3Cpath fill-rule=%22evenodd%22 d=%22M12.2 13.6a7 7 0 111.4-1.4l5.4 5.4-1.4 1.4-5.4-5.4zM13 8A5 5 0 113 8a5 5 0 0110 0z%22/%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-invert.oo-ui-icon-search, .mw-ui-icon-search-invert:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=search&variant=invert&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Esearch%3C/title%3E%3Cg fill=%22%23fff%22%3E%3Cpath fill-rule=%22evenodd%22 d=%22M12.2 13.6a7 7 0 111.4-1.4l5.4 5.4-1.4 1.4-5.4-5.4zM13 8A5 5 0 113 8a5 5 0 0110 0z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-progressive.oo-ui-icon-search, .mw-ui-icon-search-progressive:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=search&variant=progressive&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Esearch%3C/title%3E%3Cg fill=%22%2336c%22%3E%3Cpath fill-rule=%22evenodd%22 d=%22M12.2 13.6a7 7 0 111.4-1.4l5.4 5.4-1.4 1.4-5.4-5.4zM13 8A5 5 0 113 8a5 5 0 0110 0z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-icon-subtract, .mw-ui-icon-subtract:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=subtract&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Esubtract%3C/title%3E%3Cpath d=%22M4 9h12v2H4z%22/%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-invert.oo-ui-icon-subtract, .mw-ui-icon-subtract-invert:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=subtract&variant=invert&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Esubtract%3C/title%3E%3Cg fill=%22%23fff%22%3E%3Cpath d=%22M4 9h12v2H4z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-progressive.oo-ui-icon-subtract, .mw-ui-icon-subtract-progressive:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=subtract&variant=progressive&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Esubtract%3C/title%3E%3Cg fill=%22%2336c%22%3E%3Cpath d=%22M4 9h12v2H4z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-destructive.oo-ui-icon-subtract, .mw-ui-icon-subtract-destructive:before {
+            background-image: url(/w/load.php?modules=oojs-ui-core.icons&image=subtract&variant=destructive&format=rasterized&skin=vector&version=16ke3);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Esubtract%3C/title%3E%3Cg fill=%22%23d33%22%3E%3Cpath d=%22M4 9h12v2H4z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-indicator-clear {
+            background-image: url(/w/load.php?modules=oojs-ui.styles.indicators&image=clear&format=rasterized&skin=vector&version=wmral);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Eclear%3C/title%3E%3Cpath d=%22M10 0a10 10 0 1010 10A10 10 0 0010 0zm5.66 14.24l-1.41 1.41L10 11.41l-4.24 4.25-1.42-1.42L8.59 10 4.34 5.76l1.42-1.42L10 8.59l4.24-4.24 1.41 1.41L11.41 10z%22/%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-invert.oo-ui-indicator-clear {
+            background-image: url(/w/load.php?modules=oojs-ui.styles.indicators&image=clear&variant=invert&format=rasterized&skin=vector&version=wmral);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Eclear%3C/title%3E%3Cg fill=%22%23fff%22%3E%3Cpath d=%22M10 0a10 10 0 1010 10A10 10 0 0010 0zm5.66 14.24l-1.41 1.41L10 11.41l-4.24 4.25-1.42-1.42L8.59 10 4.34 5.76l1.42-1.42L10 8.59l4.24-4.24 1.41 1.41L11.41 10z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-indicator-up {
+            background-image: url(/w/load.php?modules=oojs-ui.styles.indicators&image=up&format=rasterized&skin=vector&version=wmral);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 12 12%22%3E%3Ctitle%3Eup%3C/title%3E%3Cpath d=%22M10.035 9.026L6 5.168 2.053 9.026 1 7.974l5-5 5 5z%22/%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-invert.oo-ui-indicator-up {
+            background-image: url(/w/load.php?modules=oojs-ui.styles.indicators&image=up&variant=invert&format=rasterized&skin=vector&version=wmral);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 12 12%22%3E%3Ctitle%3Eup%3C/title%3E%3Cg fill=%22%23fff%22%3E%3Cpath d=%22M10.035 9.026L6 5.168 2.053 9.026 1 7.974l5-5 5 5z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-indicator-down {
+            background-image: url(/w/load.php?modules=oojs-ui.styles.indicators&image=down&format=rasterized&skin=vector&version=wmral);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 12 12%22%3E%3Ctitle%3Edown%3C/title%3E%3Cpath d=%22M10.085 2.943L6.05 6.803l-3.947-3.86L1.05 3.996l5 5 5-5z%22/%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-invert.oo-ui-indicator-down {
+            background-image: url(/w/load.php?modules=oojs-ui.styles.indicators&image=down&variant=invert&format=rasterized&skin=vector&version=wmral);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 12 12%22%3E%3Ctitle%3Edown%3C/title%3E%3Cg fill=%22%23fff%22%3E%3Cpath d=%22M10.085 2.943L6.05 6.803l-3.947-3.86L1.05 3.996l5 5 5-5z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .oo-ui-indicator-required {
+            background-image: url(/w/load.php?modules=oojs-ui.styles.indicators&image=required&format=rasterized&skin=vector&version=wmral);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Erequired%3C/title%3E%3Cpath d=%22M8.5 0h3v20h-3z%22/%3E%3Cpath d=%22M19.41 13.701l-1.5 2.598L.59 6.3l1.5-2.598z%22/%3E%3Cpath d=%22M17.91 3.701l1.5 2.598-17.32 10-1.5-2.598z%22/%3E%3C/svg%3E")
+        }
+
+        .oo-ui-image-invert.oo-ui-indicator-required {
+            background-image: url(/w/load.php?modules=oojs-ui.styles.indicators&image=required&variant=invert&format=rasterized&skin=vector&version=wmral);
+            background-image: linear-gradient(transparent, transparent), url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2220%22 height=%2220%22 viewBox=%220 0 20 20%22%3E%3Ctitle%3Erequired%3C/title%3E%3Cg fill=%22%23fff%22%3E%3Cpath d=%22M8.5 0h3v20h-3z%22/%3E%3Cpath d=%22M19.41 13.701l-1.5 2.598L.59 6.3l1.5-2.598z%22/%3E%3Cpath d=%22M17.91 3.701l1.5 2.598-17.32 10-1.5-2.598z%22/%3E%3C/g%3E%3C/svg%3E")
+        }
+
+        .ve-init-mw-progressBarWidget {
+            height: 1em;
+            overflow: hidden;
+            margin: 0 25%
+        }
+
+        .ve-init-mw-progressBarWidget-bar {
+            height: 1em;
+            width: 0
+        }
+
+        .ve-init-mw-progressBarWidget {
+            background-color: #fff;
+            box-sizing: border-box;
+            height: 0.875em;
+            border: 1px solid #36c;
+            border-radius: 0.875em;
+            box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15)
+        }
+
+        .ve-init-mw-progressBarWidget-bar {
+            background-color: #36c;
+            height: 0.875em
+        }
+
+        @media screen {
+            .toctoggle {
+                -moz-user-select: none;
+                -webkit-user-select: none;
+                -ms-user-select: none;
+                user-select: none;
+                font-size: 94%
+            }
+        }
+
+        .translationtargetstar {
+            background-image: url(https://upload.wikimedia.org/wikipedia/commons/thumb/3/33/Watch-icon.svg/16px-Watch-icon.svg.png);
+            position: absolute;
+            margin-top: 3px;
+            margin-left: -17px;
+            cursor: pointer;
+            width: 16px;
+            height: 15px
+        }
+
+        .translationtargetstar:hover {
+            background-image: url(https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/Watch-icon-hl.svg/16px-Watch-icon-hl.svg.png)
+        }
+
+        .translationtargetstarchecked {
+            background-image: url(https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/Unwatch-icon.svg/16px-Unwatch-icon.svg.png);
+            position: absolute;
+            margin-top: 3px;
+            margin-left: -17px;
+            cursor: pointer;
+            width: 16px;
+            height: 15px
+        }
+
+        .translationtargetstarchecked:hover {
+            background-image: url(https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Unwatch-icon-hl.svg/16px-Unwatch-icon-hl.svg.png)
+        }
+
+        @-webkit-keyframes centralAuthPPersonalAnimation {
+            0% {
+                opacity: 0;
+                -webkit-transform: translateY(-20px)
+            }
+            100% {
+                opacity: 1;
+                -webkit-transform: translateY(0)
+            }
+        }
+
+        @keyframes centralAuthPPersonalAnimation {
+            0% {
+                opacity: 0;
+                transform: translateY(-20px)
+            }
+            100% {
+                opacity: 1;
+                transform: translateY(0)
+            }
+        }
+
+        .centralAuthPPersonalAnimation {
+            -webkit-animation-duration: 1s;
+            animation-duration: 1s;
+            -webkit-animation-fill-mode: both;
+            animation-fill-mode: both;
+            -webkit-animation-name: centralAuthPPersonalAnimation;
+            animation-name: centralAuthPPersonalAnimation
+        }
+
+        .uls-menu {
+            border-radius: 2px;
+            font-size: medium
+        }
+
+        .uls-search, .uls-language-settings-close-block {
+            border-top-right-radius: 2px;
+            border-top-left-radius: 2px
+        }
+
+        .uls-language-list {
+            border-bottom-right-radius: 2px;
+            border-bottom-left-radius: 2px
+        }
+
+        .uls-menu.callout:before, .uls-menu.callout:after {
+            border-top: 10px solid transparent;
+            border-bottom: 10px solid transparent;
+            display: inline-block;
+            top: 17px;
+            position: absolute;
+            content: ''
+        }
+
+        .uls-menu.callout.selector-right:before {
+            border-left: 10px solid #c8ccd1;
+            right: -11px
+        }
+
+        .uls-menu.callout.selector-right:after {
+            border-left: 10px solid #fff;
+            right: -10px
+        }
+
+        .uls-menu.callout.selector-left:before {
+            border-right: 10px solid #c8ccd1;
+            left: -11px
+        }
+
+        .uls-menu.callout.selector-left:after {
+            border-right: 10px solid #fff;
+            left: -10px
+        }
+
+        .uls-ui-languages button {
+            margin: 5px 15px 5px 0;
+            white-space: nowrap;
+            overflow: hidden
+        }
+
+        .uls-search-wrapper-wrapper {
+            position: relative;
+            padding-left: 40px;
+            margin-top: 5px;
+            margin-bottom: 5px
+        }
+
+        .uls-icon-back {
+            background: transparent url(/w/extensions/UniversalLanguageSelector/resources/images/back-grey-ltr.svg?01868) no-repeat scroll center center;
+            background-size: 28px;
+            height: 32px;
+            width: 40px;
+            display: block;
+            position: absolute;
+            left: 0;
+            border-right: 1px solid #c8ccd1;
+            opacity: 0.8
+        }
+
+        .uls-icon-back:hover {
+            opacity: 1;
+            cursor: pointer
+        }
+
+        .uls-menu .uls-no-results-view .uls-no-found-more {
+            background-color: #fff
+        }
+
+        .uls-menu .uls-no-results-view h3 {
+            padding: 0 28px;
+            margin: 0;
+            color: #54595d;
+            font-size: 1em;
+            font-weight: normal
+        }
+
+        .skin-vector .uls-menu {
+            border-color: #c8ccd1;
+            box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.25);
+            font-size: 0.875em
+        }
+
+        .skin-vector .uls-search {
+            border-bottom-color: #c8ccd1
+        }
+
+        .skin-vector .uls-search-label {
+            opacity: 0.51;
+            -webkit-transition: opacity 250ms;
+            transition: opacity 250ms
+        }
+
+        .skin-vector .uls-search-wrapper:hover .uls-search-label {
+            opacity: 0.87
+        }
+
+        .skin-vector .uls-filtersuggestion {
+            color: #72777d
+        }
+
+        .skin-vector .uls-lcd-region-title {
+            color: #54595d
+        }
+
+        body.skin-monobook li#ca-talk {
+            margin-right: 0.3em
+        }
+
+        body.skin-monobook li#ca-edit {
+            margin-left: 1.6em
+        }
+
+        #uls-settings-block {
+            background-color: #f8f9fa;
+            border-top: 1px solid #c8ccd1;
+            padding-left: 10px;
+            line-height: 1.2em;
+            border-radius: 0 0 2px 2px
+        }
+
+        #uls-settings-block > button {
+            background: left top transparent no-repeat;
+            background-size: 20px auto;
+            color: #54595d;
+            display: inline-block;
+            margin: 8px 15px;
+            border: 0;
+            padding: 0 0 0 26px;
+            font-size: medium;
+            cursor: pointer
+        }
+
+        #uls-settings-block > button:hover {
+            color: #202122
+        }
+
+        #uls-settings-block > button.display-settings-block {
+            background-image: url(/w/extensions/UniversalLanguageSelector/resources/images/display.svg?b78f7)
+        }
+
+        #uls-settings-block > button.input-settings-block {
+            background-image: url(/w/extensions/UniversalLanguageSelector/resources/images/input.svg?e7c85)
+        }
+
+        .uls-tipsy.uls-tipsy {
+            z-index: 1000
+        }</style>
+    <style>
+        .ve-init-mw-tempWikitextEditorWidget {
+            border: 0;
+            padding: 0;
+            color: inherit;
+            line-height: 1.5em;
+            width: 100%;
+            -moz-tab-size: 4;
+            tab-size: 4;
+        }
+
+        .ve-init-mw-tempWikitextEditorWidget:focus {
+            outline: 0;
+            padding: 0
+        }
+
+        .ve-init-mw-tempWikitextEditorWidget::selection {
+            background: rgba(109, 169, 247, 0.5);
+        }
+
+        #p-lang .body ul .uls-trigger, #p-lang .pBody ul .uls-trigger {
+            background-image: none;
+            padding: 0
+        }
+
+        #p-lang .mw-interlanguage-selector, #p-lang .mw-interlanguage-selector:active {
+            background-image: url(/w/extensions/UniversalLanguageSelector/resources/images/language-base20.svg?b7954);
+            background-position: left 4px center;
+            background-repeat: no-repeat;
+            background-size: 16px;
+            margin: 4px 0 8px;
+            padding: 4px 8px 4px 26px;
+            font-size: 13px;
+            font-weight: normal;
+            text-align: left;
+            cursor: pointer
+        }
+
+        .mw-interlanguage-selector.selector-open {
+            background-color: #c8ccd1
+        }
+
+        .interlanguage-uls-menu:before, .interlanguage-uls-menu:after {
+            border-top: 10px solid transparent;
+            border-bottom: 10px solid transparent;
+            display: inline-block;
+            top: 17px;
+            position: absolute;
+            content: ''
+        }
+
+        .interlanguage-uls-menu.selector-right:before {
+            border-left: 10px solid #c8ccd1;
+            right: -11px
+        }
+
+        .interlanguage-uls-menu.selector-right:after {
+            border-left: 10px solid #fff;
+            right: -10px
+        }
+
+        .interlanguage-uls-menu.selector-left:before {
+            border-right: 10px solid #c8ccd1;
+            left: -11px
+        }
+
+        .interlanguage-uls-menu.selector-left:after {
+            border-right: 10px solid #fff;
+            left: -10px
+        }
+
+        .zh-dial-map__container {
+            margin: auto;
+            max-width: 1100px;
+            position: relative
+        }
+
+        .zh-dial-map__inputContainer {
+            position: absolute;
+            top: 0;
+            left: 0;
+            background: rgba(255, 255, 255, 0.5);
+            z-index: 1;
+            margin: 1em;
+            padding: 0.5em;
+            font-size: 1em;
+            opacity: 0.5;
+            transition: opacity 1s;
+        }
+
+        .zh-dial-map__inputContainer:hover {
+            opacity: 1;
+            transition: opacity 0.2s;
+        }
+
+        .zh-dial-map__inputContainer input {
+            vertical-align: middle
+        }
+
+        .zh-dial-map__zoomContainer:before {
+            content: "10% "
+        }
+
+        .zh-dial-map__zoomContainer:after {
+            content: " 400%"
+        }
+
+        .zh-dial-map__zoomController {
+            width: 120px
+        }
+
+        .zh-dial-map__frame {
+            max-height: 80vh;
+            width: 100%;
+            box-sizing: border-box;
+        }
+
+        .zh-dial-map__map {
+            position: relative;
+            margin: auto;
+        }
+
+        .zh-dial-map__map img {
+            pointer-events: none;
+            user-select: none;
+            -moz-user-select: none;
+            -webkit-user-select: none;
+            -ms-user-select: none
+        }
+
+        .zh-dial-map__dot, .zh-dial-map__legend-row-dot {
+            height: 10px;
+            width: 10px;
+            border-radius: 100%;
+            text-indent: 100%;
+            overflow: hidden
+        }
+
+        .zh-dial-map__legend-row-dot {
+            display: inline-block;
+            margin-right: 0.5em
+        }
+
+        .zh-dial-map__dot {
+            position: absolute;
+            transform: translate(-50%, -50%);
+            cursor: help
+        }
+
+        .zh-dial-map__dot:hover, .zh-dial-map__dot--hover {
+            opacity: 0.75;
+            height: 20px;
+            width: 20px;
+            z-index: 1;
+            border: 5px solid white
+        }
+
+        .zh-dial-map__dot--superHover {
+            opacity: 1;
+            height: 30px;
+            width: 30px;
+            z-index: 2;
+            animation: .4s infinite alternate dotPulse;
+            pointer-events: none
+        }
+
+        @keyframes dotPulse {
+            from {
+                opacity: 0.75;
+                height: 20px;
+                width: 20px
+            }
+            to {
+                opacity: 1;
+                height: 30px;
+                width: 30px
+            }
+        }
+
+        .zh-dial-map__legend {
+            -ms-column-count: 5;
+            -moz-column-count: 5;
+            -webkit-column-count: 5;
+            column-count: 5;
+            line-height: 1.4;
+            padding: 0.5em
+        }
+
+        .zh-dial-map__legend-row--hover, .zh-dial-map__legend-row .oo-ui-popupWidget-popup li:hover {
+            background: rgba(128, 255, 0, 0.25)
+        }
+
+        .zh-dial-map__legend-row .oo-ui-popupWidget-popup {
+            background-color: rgba(255, 255, 255, 0.75);
+            text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.5)
+        }
+
+        .zh-dial-map__legend-row .oo-ui-popupWidget:before, .zh-dial-map__legend-row .oo-ui-popupWidget:after {
+            content: "";
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            z-index: 2
+        }
+
+        .zh-dial-map__legend-row .oo-ui-popupWidget:before {
+            top: -1.2em;
+            background: rgba(255, 0, 0, 0.05);
+            background: transparent
+        }
+
+        .zh-dial-map__legend-row .oo-ui-popupWidget:after {
+            bottom: -1.2em;
+            background: rgba(0, 0, 255, 0.05);
+            background: transparent
+        }
+
+        .zh-dial-map__legend-row .oo-ui-popupWidget-popup {
+            z-index: 3;
+        }</style>
+    <style>
+        .ve-activated .ve-init-mw-desktopArticleTarget-editableContent #toc, .ve-activated #siteNotice, .ve-activated .mw-indicators, .ve-activated #t-print, .ve-activated #t-permalink, .ve-activated #p-coll-print_export, .ve-activated #t-cite, .ve-deactivating .ve-ui-surface, .ve-active .ve-init-mw-desktopArticleTarget-editableContent, .ve-active .ve-init-mw-tempWikitextEditorWidget {
+            display: none
+        }
+
+        .ve-activating .ve-ui-surface {
+            height: 0;
+            padding: 0 !important;
+            overflow: hidden
+        }
+
+        .ve-loading #content > :not(.ve-init-mw-desktopArticleTarget-loading-overlay), .ve-activated .ve-init-mw-desktopArticleTarget-uneditableContent {
+            pointer-events: none;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            opacity: 0.5
+        }
+
+        .ve-activated #firstHeading {
+            -webkit-user-select: text;
+            -moz-user-select: text;
+            -ms-user-select: text;
+            user-select: text;
+            pointer-events: auto;
+            cursor: text
+        }
+
+        .ve-activated #firstHeading a {
+            pointer-events: none
+        }
+
+        .ve-activated #catlinks {
+            cursor: pointer
+        }
+
+        .ve-activated #catlinks:hover {
+            background: #e9f2fd
+        }
+
+        .ve-activated #catlinks a {
+            opacity: 1
+        }
+
+        .ve-activated #content {
+            position: relative
+        }
+
+        .ve-init-mw-desktopArticleTarget-loading-overlay {
+            position: absolute;
+            top: 1.25em;
+            left: 0;
+            right: 0;
+            z-index: 1;
+            margin-top: -0.5em
+        }
+
+        .ve-init-mw-desktopArticleTarget-toolbarPlaceholder {
+            transition: height 250ms ease;
+            height: 0;
+        }
+
+        .oo-ui-element-hidden {
+            display: none !important;
+        }
+
+        .mw-editsection {
+            unicode-bidi: -moz-isolate;
+            unicode-bidi: -webkit-isolate;
+            unicode-bidi: isolate
+        }
+
+        .mw-editsection:before {
+            content: '\200B'
+        }
+
+        .mw-editsection a {
+            white-space: nowrap
+        }
+
+        .mw-editsection-divider {
+            color: #54595d
+        }
+
+        .ve-init-mw-desktopArticleTarget-toolbarPlaceholder {
+            border-bottom: 1px solid #c8ccd1;
+            box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1)
+        }
+
+        .ve-init-mw-desktopArticleTarget-toolbarPlaceholder-open {
+            height: 42px
+        }
+
+        .ve-init-mw-desktopArticleTarget-toolbar, .ve-init-mw-desktopArticleTarget-toolbarPlaceholder {
+            font-size: 0.875em;
+            margin: -1.42857143em -0.57142857em 1.42857143em -0.57142857em
+        }
+
+        .skin-vector-legacy .ve-init-mw-desktopArticleTarget-toolbar, .skin-vector-legacy .ve-init-mw-desktopArticleTarget-toolbarPlaceholder {
+            margin: -1.14em -1.14em 1.14em -1.14em;
+        }
+
+        @media screen and (min-width: 982px) {
+            .skin-vector-legacy .ve-init-mw-desktopArticleTarget-toolbar, .skin-vector-legacy .ve-init-mw-desktopArticleTarget-toolbarPlaceholder {
+                margin: -1.43em -1.71em 1.43em -1.71em
+            }
+        }</style>
+    <meta name="ResourceLoaderDynamicStyles" content="">
+    <link rel="stylesheet" href="./hodati-60892603_files/load(2).php">
+    <link rel="stylesheet" href="./hodati-60892603_files/load(3).php">
+    <meta name="generator" content="MediaWiki 1.38.0-wmf.2">
+    <meta name="referrer" content="origin">
+    <meta name="referrer" content="origin-when-crossorigin">
+    <meta name="referrer" content="origin-when-cross-origin">
+    <meta name="robots" content="noindex,nofollow">
+    <meta name="format-detection" content="telephone=no">
+    <meta property="og:title" content="hodati - Wiktionary">
+    <meta property="og:type" content="website">
+    <link rel="alternate" media="only screen and (max-width: 720px)" href="https://en.m.wiktionary.org/wiki/hodati">
+    <link rel="alternate" type="application/x-wiki" title="Edit"
+          href="https://en.wiktionary.org/w/index.php?title=hodati&amp;action=edit">
+    <link rel="edit" title="Edit" href="https://en.wiktionary.org/w/index.php?title=hodati&amp;action=edit">
+    <link rel="apple-touch-icon" href="https://en.wiktionary.org/static/apple-touch/wiktionary/en.png">
+    <link rel="shortcut icon" href="https://en.wiktionary.org/static/favicon/wiktionary/en.ico">
+    <link rel="search" type="application/opensearchdescription+xml"
+          href="https://en.wiktionary.org/w/opensearch_desc.php" title="Wiktionary (en)">
+    <link rel="EditURI" type="application/rsd+xml" href="https://en.wiktionary.org/w/api.php?action=rsd">
+    <link rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/">
+    <link rel="canonical" href="https://en.wiktionary.org/wiki/hodati">
+    <link rel="dns-prefetch" href="https://meta.wikimedia.org/">
+    <link rel="dns-prefetch" href="https://login.wikimedia.org/">
+    <style>.visible-to-anons {
+        display: inline;
+    }</style>
+</head>
+<body class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable page-hodati rootpage-hodati skin-vector action-view skin-vector-legacy">
+<div id="mw-page-base" class="noprint"></div>
+<div id="mw-head-base" class="noprint"></div>
+<div id="content" class="mw-body" role="main">
+    <a id="top"></a>
+    <div id="siteNotice">
+        <div id="centralNotice"></div><!-- CentralNotice --></div>
+    <div class="mw-indicators">
+    </div>
+    <h1 id="firstHeading" class="firstHeading">hodati</h1>
+    <div id="bodyContent" class="vector-body">
+        <div id="siteSub" class="noprint">Definition from Wiktionary, the free dictionary</div>
+        <div id="contentSub">
+            <div class="mw-revision warningbox">
+                <div id="mw-revision-info">Archived revision by <a
+                        href="https://en.wiktionary.org/wiki/Special:Contributions/141.138.54.118"
+                        class="mw-userlink mw-anonuserlink" title="Special:Contributions/141.138.54.118">
+                    <bdi>141.138.54.118</bdi>
+                </a> <span class="mw-usertoollinks">(<a
+                        href="https://en.wiktionary.org/w/index.php?title=User_talk:141.138.54.118&amp;action=edit&amp;redlink=1"
+                        class="new mw-usertoollinks-talk"
+                        title="User talk:141.138.54.118 (page does not exist)">talk</a>)</span> as of 02:19, 21 October
+                    2020.
+                </div>
+                <div id="mw-revision-nav">(<a
+                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;diff=prev&amp;oldid=60892603"
+                        title="hodati">diff</a>) <a
+                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;direction=prev&amp;oldid=60892603"
+                        title="hodati">← Older revision</a> | Latest revision (diff) | Newer revision → (diff)
+                </div>
+            </div>
+        </div>
+        <div id="contentSub2"></div>
+
+        <div id="jump-to-nav"></div>
+        <a class="mw-jump-link" href="https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603#mw-head">Jump
+            to navigation</a>
+        <a class="mw-jump-link"
+           href="https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603#searchInput">Jump to search</a>
+        <div id="mw-content-text" class="mw-body-content mw-content-ltr" lang="en" dir="ltr">
+            <div class="mw-parser-output">
+                <div id="toc" class="toc" role="navigation" aria-labelledby="mw-toc-heading"><input type="checkbox"
+                                                                                                    role="button"
+                                                                                                    id="toctogglecheckbox"
+                                                                                                    class="toctogglecheckbox"
+                                                                                                    style="display:none">
+                    <div class="toctitle" lang="en" dir="ltr"><h2 id="mw-toc-heading">Contents</h2><span
+                            class="toctogglespan"><label class="toctogglelabel" for="toctogglecheckbox"></label></span>
+                    </div>
+                    <ul>
+                        <li class="toclevel-1 tocsection-1"><a
+                                href="https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603#Serbo-Croatian"><span
+                                class="tocnumber">1</span> <span class="toctext">Serbo-Croatian</span></a>
+                            <ul>
+                                <li class="toclevel-2 tocsection-2"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603#Etymology"><span
+                                        class="tocnumber">1.1</span> <span class="toctext">Etymology</span></a></li>
+                                <li class="toclevel-2 tocsection-3"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603#Pronunciation"><span
+                                        class="tocnumber">1.2</span> <span class="toctext">Pronunciation</span></a></li>
+                                <li class="toclevel-2 tocsection-4"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603#Verb"><span
+                                        class="tocnumber">1.3</span> <span class="toctext">Verb</span></a>
+                                    <ul>
+                                        <li class="toclevel-3 tocsection-5"><a
+                                                href="https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603#Conjugation"><span
+                                                class="tocnumber">1.3.1</span> <span class="toctext">Conjugation</span></a>
+                                        </li>
+                                        <li class="toclevel-3 tocsection-6"><a
+                                                href="https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603#Synonyms"><span
+                                                class="tocnumber">1.3.2</span> <span class="toctext">Synonyms</span></a>
+                                        </li>
+                                        <li class="toclevel-3 tocsection-7"><a
+                                                href="https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603#Derived_terms"><span
+                                                class="tocnumber">1.3.3</span> <span
+                                                class="toctext">Derived terms</span></a></li>
+                                        <li class="toclevel-3 tocsection-8"><a
+                                                href="https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603#Related_terms"><span
+                                                class="tocnumber">1.3.4</span> <span
+                                                class="toctext">Related terms</span></a></li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </div>
+
+                <h2><span class="mw-headline" id="Serbo-Croatian">Serbo-Croatian</span><span
+                        class="mw-editsection"><span class="mw-editsection-bracket">[</span><a
+                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;action=edit&amp;section=1"
+                        title="Edit section: Serbo-Croatian">edit</a><span
+                        class="mw-editsection-bracket">]</span></span></h2>
+                <h3><span class="mw-headline" id="Etymology">Etymology</span><span class="mw-editsection"><span
+                        class="mw-editsection-bracket">[</span><a
+                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;action=edit&amp;section=2"
+                        title="Edit section: Etymology">edit</a><span class="mw-editsection-bracket">]</span></span>
+                </h3>
+                <p>From <i class="Latn mention" lang="sh"><a href="https://en.wiktionary.org/wiki/hod#Serbo-Croatian"
+                                                             title="hod">hȏd</a></i> <span
+                        class="mention-gloss-paren annotation-paren">(</span><span
+                        class="mention-gloss-double-quote">“</span><span class="mention-gloss">walk, pace</span><span
+                        class="mention-gloss-double-quote">”</span><span
+                        class="mention-gloss-paren annotation-paren">)</span>. Cognates include <span class="etyl"><a
+                        href="https://en.wikipedia.org/wiki/Czech_language" class="extiw"
+                        title="w:Czech language">Czech</a></span> <i class="Latn mention" lang="cs"><a
+                        href="https://en.wiktionary.org/wiki/chodit#Czech" title="chodit">chodit</a></i> and <span
+                        class="etyl"><a href="https://en.wikipedia.org/wiki/Russian_language" class="extiw"
+                                        title="w:Russian language">Russian</a></span> <i class="Cyrl mention" lang="ru"><a
+                        href="https://en.wiktionary.org/wiki/%D1%85%D0%BE%D0%B4%D0%B8%D1%82%D1%8C#Russian"
+                        title="ходить">ходить</a></i> <span class="mention-gloss-paren annotation-paren">(</span><span
+                        lang="ru-Latn" class="mention-tr tr Latn">xoditʹ</span><span
+                        class="mention-gloss-paren annotation-paren">)</span>.
+                </p>
+                <h3><span class="mw-headline" id="Pronunciation">Pronunciation</span><span class="mw-editsection"><span
+                        class="mw-editsection-bracket">[</span><a
+                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;action=edit&amp;section=3"
+                        title="Edit section: Pronunciation">edit</a><span class="mw-editsection-bracket">]</span></span>
+                </h3>
+                <ul>
+                    <li><a href="https://en.wiktionary.org/wiki/Wiktionary:International_Phonetic_Alphabet"
+                           title="Wiktionary:International Phonetic Alphabet">IPA</a><sup>(<a
+                            href="https://en.wiktionary.org/wiki/Appendix:Serbo-Croatian_pronunciation"
+                            title="Appendix:Serbo-Croatian pronunciation">key</a>)</sup>: <span
+                            class="IPA">/xǒːdati/</span></li>
+                    <li>Hyphenation: <span class="Latn" lang="sh">ho‧da‧ti</span></li>
+                </ul>
+                <h3><span class="mw-headline" id="Verb">Verb</span><span class="mw-editsection"><span
+                        class="mw-editsection-bracket">[</span><a
+                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;action=edit&amp;section=4"
+                        title="Edit section: Verb">edit</a><span class="mw-editsection-bracket">]</span></span></h3>
+                <p><strong class="Latn headword" lang="sh">hódati</strong>&nbsp;<span class="gender"><abbr
+                        title="imperfective aspect">impf</abbr></span> (<i>Cyrillic spelling</i> <b class="Cyrl"
+                                                                                                    lang="sh"><a
+                        href="https://en.wiktionary.org/wiki/%D1%85%D0%BE%D0%B4%D0%B0%D1%82%D0%B8#Serbo-Croatian"
+                        title="ходати">хо́дати</a></b>)
+                </p>
+                <ol>
+                    <li><span class="ib-brac">(</span><span class="ib-content"><a
+                            href="https://en.wiktionary.org/wiki/Appendix:Glossary#intransitive"
+                            title="Appendix:Glossary">intransitive</a></span><span class="ib-brac">)</span> to <a
+                            href="https://en.wiktionary.org/wiki/walk" title="walk">walk</a>, <a
+                            href="https://en.wiktionary.org/wiki/pace" title="pace">pace</a></li>
+                    <li><span class="ib-brac">(</span><span class="ib-content"><a
+                            href="https://en.wiktionary.org/wiki/Appendix:Glossary#intransitive"
+                            title="Appendix:Glossary">intransitive</a></span><span class="ib-brac">)</span> to <a
+                            href="https://en.wiktionary.org/wiki/stride" title="stride">stride</a></li>
+                    <li><span class="ib-brac">(</span><span class="ib-content"><a
+                            href="https://en.wiktionary.org/wiki/Appendix:Glossary#intransitive"
+                            title="Appendix:Glossary">intransitive</a></span><span class="ib-brac">)</span> to <a
+                            href="https://en.wiktionary.org/wiki/saunter" title="saunter">saunter</a>, <a
+                            href="https://en.wiktionary.org/wiki/stroll" title="stroll">stroll</a>, <a
+                            href="https://en.wiktionary.org/wiki/amble" title="amble">amble</a></li>
+                    <li><span class="ib-brac">(</span><span class="ib-content"><a
+                            href="https://en.wiktionary.org/wiki/Appendix:Glossary#intransitive"
+                            title="Appendix:Glossary">intransitive</a><span class="ib-comma">,</span> <a
+                            href="https://en.wiktionary.org/wiki/Appendix:Glossary#figurative"
+                            title="Appendix:Glossary">figuratively</a><span class="ib-comma">,</span> <a
+                            href="https://en.wiktionary.org/wiki/Appendix:Glossary#colloquial"
+                            title="Appendix:Glossary">colloquial</a></span><span class="ib-brac">)</span> to <a
+                            href="https://en.wiktionary.org/wiki/date" title="date">date</a> (to be romantically
+                        involved with another)
+                    </li>
+                    <li><span class="ib-brac">(</span><span class="ib-content"><a
+                            href="https://en.wiktionary.org/wiki/Appendix:Glossary#intransitive"
+                            title="Appendix:Glossary">intransitive</a><span class="ib-comma">,</span> <a
+                            href="https://en.wiktionary.org/wiki/Appendix:Glossary#figurative"
+                            title="Appendix:Glossary">figuratively</a><span class="ib-comma">,</span> <a
+                            href="https://en.wiktionary.org/wiki/Appendix:Glossary#colloquial"
+                            title="Appendix:Glossary">colloquial</a></span><span class="ib-brac">)</span> <a
+                            href="https://en.wiktionary.org/wiki/run" title="run">run</a>, <a
+                            href="https://en.wiktionary.org/wiki/work" title="work">work</a>, <a
+                            href="https://en.wiktionary.org/wiki/function" title="function">function</a> (operate or
+                        fulfill its purpose satisfactorily)
+                    </li>
+                </ol>
+                <h4><span class="mw-headline" id="Conjugation">Conjugation</span><span class="mw-editsection"><span
+                        class="mw-editsection-bracket">[</span><a
+                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;action=edit&amp;section=5"
+                        title="Edit section: Conjugation">edit</a><span class="mw-editsection-bracket">]</span></span>
+                </h4>
+                <div class="NavFrame">
+                    <div class="NavHead" style="background: rgb(217, 235, 255); cursor: pointer;"><span
+                            class="NavToggle"><a role="button" tabindex="0">show ▼</a></span>Conjugation of <i
+                            class="Latn mention" lang="sh">hodati</i></div>
+                    <div class="NavContent" style="display: none;">
+                        <table class="inflection-table" style="text-align:center; width: 100%;">
+
+                            <tbody>
+                            <tr>
+                                <td style="height:3em; background-color:#d9ebff;" colspan="2"><b>Infinitive: <span
+                                        class="Latn" lang="sh"><strong class="selflink">hodati</strong></span></b>
+                                </td>
+                                <td colspan="2" style="background-color:#d9ebff;"><b>Present verbal adverb: <span
+                                        class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/hodaju%C4%87i#Serbo-Croatian"
+                                        title="hodajući">hódajūći</a></span></b>
+                                </td>
+                                <td colspan="2" style="background-color:#d9ebff;"><b>Past verbal adverb: —</b>
+                                </td>
+                                <td colspan="2" style="background-color:#d9ebff;"><b>Verbal noun: <span class="Latn"
+                                                                                                        lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodanje&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodanje (page does not exist)">hódānje</a></span></b>
+                                </td>
+                            </tr>
+                            <tr style="background-color:#d5d5ff;">
+                                <td colspan="2"><b>Number</b>
+                                </td>
+                                <td colspan="3"><b>Singular</b>
+                                </td>
+                                <td colspan="3"><b>Plural</b>
+                                </td>
+                            </tr>
+                            <tr style="background-color:#d5d5ff;">
+                                <td colspan="2"><b>Person</b>
+                                </td>
+                                <td style="width: 13.3%;"><b>1st</b>
+                                </td>
+                                <td style="width: 13.3%;"><b>2nd</b>
+                                </td>
+                                <td style="width: 13.3%;"><b>3rd</b>
+                                </td>
+                                <td style="width: 13.3%;"><b>1st</b>
+                                </td>
+                                <td style="width: 13.3%;"><b>2nd</b>
+                                </td>
+                                <td style="width: 13.3%;"><b>3rd</b>
+                                </td>
+                            </tr>
+                            <tr style="background-color:#ccddff;">
+                                <td colspan="2"><b>Verbal forms</b>
+                                </td>
+                                <td><b><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/ja#Serbo-Croatian" title="ja">ja</a></span></b>
+                                </td>
+                                <td><b><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/ti#Serbo-Croatian" title="ti">ti</a></span></b>
+                                </td>
+                                <td><b><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/on#Serbo-Croatian" title="on">on</a></span></b>
+                                    / <b><span class="Latn" lang="sh"><a
+                                            href="https://en.wiktionary.org/wiki/ona#Serbo-Croatian" title="ona">ona</a></span></b>
+                                    / <b><span class="Latn" lang="sh"><a
+                                            href="https://en.wiktionary.org/wiki/ono#Serbo-Croatian" title="ono">ono</a></span></b>
+                                </td>
+                                <td><b><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/mi#Serbo-Croatian" title="mi">mi</a></span></b>
+                                </td>
+                                <td><b><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/vi#Serbo-Croatian" title="vi">vi</a></span></b>
+                                </td>
+                                <td><b><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/oni#Serbo-Croatian"
+                                        title="oni">oni</a></span></b> / <b><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/one#Serbo-Croatian"
+                                        title="one">one</a></span></b> / <b><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/ona#Serbo-Croatian"
+                                        title="ona">ona</a></span></b>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td colspan="2" style="height:3em; background-color:#ccddff;"><b>Present</b>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/hodam#Serbo-Croatian"
+                                        title="hodam">hodam</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/hoda%C5%A1#Serbo-Croatian" title="hodaš">hodaš</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/hoda#Serbo-Croatian" title="hoda">hoda</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodamo&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodamo (page does not exist)">hodamo</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodate&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodate (page does not exist)">hodate</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodaju&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodaju (page does not exist)">hodaju</a></span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td rowspan="2" style="background-color:#ccddff;"><b>Future</b>
+                                </td>
+                                <td style="height:3em; background-color:#ccddff;"><b>Future I</b>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodat&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodat (page does not exist)">hodat</a> <a
+                                        href="https://en.wiktionary.org/wiki/%C4%87u#Serbo-Croatian"
+                                        title="ću">ću</a></span><sup>1</sup><br><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hoda%C4%87u&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodaću (page does not exist)">hodaću</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodat&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodat (page does not exist)">hodat</a> <a
+                                        href="https://en.wiktionary.org/wiki/%C4%87e%C5%A1#Serbo-Croatian" title="ćeš">ćeš</a></span><sup>1</sup><br><span
+                                        class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hoda%C4%87e%C5%A1&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodaćeš (page does not exist)">hodaćeš</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodat&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodat (page does not exist)">hodat</a> <a
+                                        href="https://en.wiktionary.org/wiki/%C4%87e#Serbo-Croatian"
+                                        title="će">će</a></span><sup>1</sup><br><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hoda%C4%87e&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodaće (page does not exist)">hodaće</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodat&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodat (page does not exist)">hodat</a> <a
+                                        href="https://en.wiktionary.org/wiki/%C4%87emo#Serbo-Croatian"
+                                        title="ćemo">ćemo</a></span><sup>1</sup><br><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hoda%C4%87emo&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodaćemo (page does not exist)">hodaćemo</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodat&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodat (page does not exist)">hodat</a> <a
+                                        href="https://en.wiktionary.org/wiki/%C4%87ete#Serbo-Croatian"
+                                        title="ćete">ćete</a></span><sup>1</sup><br><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hoda%C4%87ete&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodaćete (page does not exist)">hodaćete</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodat&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodat (page does not exist)">hodat</a> <a
+                                        href="https://en.wiktionary.org/wiki/%C4%87e#Serbo-Croatian"
+                                        title="će">će</a></span><sup>1</sup><br><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hoda%C4%87e&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodaće (page does not exist)">hodaće</a></span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="height:3em; background-color:#ccddff;"><b>Future II</b>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/budem#Serbo-Croatian"
+                                        title="budem">bȕdēm</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bude%C5%A1#Serbo-Croatian" title="budeš">bȕdēš</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bude#Serbo-Croatian" title="bude">bȕdē</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/budemo#Serbo-Croatian" title="budemo">bȕdēmo</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/budete#Serbo-Croatian" title="budete">bȕdēte</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/budu#Serbo-Croatian" title="budu">bȕdū</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a></span><sup>2</sup>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td rowspan="3" style="background-color:#ccddff;"><b>Past</b>
+                                </td>
+                                <td style="height:3em; background-color:#ccddff;"><b>Perfect</b>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a> <a
+                                        href="https://en.wiktionary.org/wiki/sam#Serbo-Croatian"
+                                        title="sam">sam</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a> <a
+                                        href="https://en.wiktionary.org/wiki/si#Serbo-Croatian" title="si">si</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a> <a
+                                        href="https://en.wiktionary.org/wiki/je#Serbo-Croatian" title="je">je</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a> <a
+                                        href="https://en.wiktionary.org/wiki/smo#Serbo-Croatian"
+                                        title="smo">smo</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a> <a
+                                        href="https://en.wiktionary.org/wiki/ste#Serbo-Croatian"
+                                        title="ste">ste</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a> <a
+                                        href="https://en.wiktionary.org/wiki/su#Serbo-Croatian" title="su">su</a></span><sup>2</sup>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="height:3em; background-color:#ccddff;"><b>Pluperfect</b><sup>3</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bio#Serbo-Croatian" title="bio">bio</a> <a
+                                        href="https://en.wiktionary.org/wiki/sam#Serbo-Croatian" title="sam">sam</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bio#Serbo-Croatian" title="bio">bio</a> <a
+                                        href="https://en.wiktionary.org/wiki/si#Serbo-Croatian" title="si">si</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bio#Serbo-Croatian" title="bio">bio</a> <a
+                                        href="https://en.wiktionary.org/wiki/je#Serbo-Croatian" title="je">je</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bili#Serbo-Croatian" title="bili">bili</a> <a
+                                        href="https://en.wiktionary.org/wiki/smo#Serbo-Croatian" title="smo">smo</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bili#Serbo-Croatian" title="bili">bili</a> <a
+                                        href="https://en.wiktionary.org/wiki/ste#Serbo-Croatian" title="ste">ste</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bili#Serbo-Croatian" title="bili">bili</a> <a
+                                        href="https://en.wiktionary.org/wiki/su#Serbo-Croatian" title="su">su</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a></span><sup>2</sup>
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td style="height: 3em; background: #ccddff;"><b>Imperfect</b>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodah&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodah (page does not exist)">hodah</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hoda%C5%A1e&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodaše (page does not exist)">hodaše</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hoda%C5%A1e&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodaše (page does not exist)">hodaše</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodasmo&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodasmo (page does not exist)">hodasmo</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodaste&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodaste (page does not exist)">hodaste</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodahu&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodahu (page does not exist)">hodahu</a></span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td colspan="2" style="height:3em; background-color:#ccddff;"><b>Conditional I</b>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a> <a
+                                        href="https://en.wiktionary.org/wiki/bih#Serbo-Croatian"
+                                        title="bih">bih</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a> <a
+                                        href="https://en.wiktionary.org/wiki/bi#Serbo-Croatian" title="bi">bi</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a> <a
+                                        href="https://en.wiktionary.org/wiki/bi#Serbo-Croatian" title="bi">bi</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a> <a
+                                        href="https://en.wiktionary.org/wiki/bismo#Serbo-Croatian"
+                                        title="bismo">bismo</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a> <a
+                                        href="https://en.wiktionary.org/wiki/biste#Serbo-Croatian"
+                                        title="biste">biste</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a> <a
+                                        href="https://en.wiktionary.org/wiki/bi#Serbo-Croatian" title="bi">bi</a></span><sup>2</sup>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td colspan="2" style="height:3em; background-color:#ccddff;"><b>Conditional II</b><sup>4</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bio#Serbo-Croatian" title="bio">bio</a> <a
+                                        href="https://en.wiktionary.org/wiki/bih#Serbo-Croatian" title="bih">bih</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bio#Serbo-Croatian" title="bio">bio</a> <a
+                                        href="https://en.wiktionary.org/wiki/bi#Serbo-Croatian" title="bi">bi</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bio#Serbo-Croatian" title="bio">bio</a> <a
+                                        href="https://en.wiktionary.org/wiki/bi#Serbo-Croatian" title="bi">bi</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bili#Serbo-Croatian" title="bili">bili</a> <a
+                                        href="https://en.wiktionary.org/wiki/bismo#Serbo-Croatian"
+                                        title="bismo">bismo</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bili#Serbo-Croatian" title="bili">bili</a> <a
+                                        href="https://en.wiktionary.org/wiki/biste#Serbo-Croatian"
+                                        title="biste">biste</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a></span><sup>2</sup>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/wiki/bili#Serbo-Croatian" title="bili">bili</a> <a
+                                        href="https://en.wiktionary.org/wiki/bi#Serbo-Croatian" title="bi">bi</a> <a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a></span><sup>2</sup>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td colspan="2" style="height:3em; background-color:#ccddff;"><b>Imperative</b>
+                                </td>
+                                <td>—
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodaj&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodaj (page does not exist)">hodaj</a></span>
+                                </td>
+                                <td>—
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodajmo&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodajmo (page does not exist)">hodajmo</a></span>
+                                </td>
+                                <td><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodajte&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodajte (page does not exist)">hodajte</a></span>
+                                </td>
+                                <td>—
+                                </td>
+                            </tr>
+                            <tr>
+                                <td colspan="2" style="height:3em; background-color:#d9ebff;"><b>Active past
+                                    participle</b>
+                                </td>
+                                <td colspan="3"><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodao&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodao (page does not exist)">hodao</a></span>&nbsp;<span
+                                        class="gender"><abbr title="masculine gender">m</abbr></span> / <span
+                                        class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodala&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodala (page does not exist)">hodala</a></span>&nbsp;<span
+                                        class="gender"><abbr title="feminine gender">f</abbr></span> / <span
+                                        class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodalo&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodalo (page does not exist)">hodalo</a></span>&nbsp;<span
+                                        class="gender"><abbr title="neuter gender">n</abbr></span>
+                                </td>
+                                <td colspan="3"><span class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodali&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodali (page does not exist)">hodali</a></span>&nbsp;<span
+                                        class="gender"><abbr title="masculine gender">m</abbr></span> / <span
+                                        class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodale&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodale (page does not exist)">hodale</a></span>&nbsp;<span
+                                        class="gender"><abbr title="feminine gender">f</abbr></span> / <span
+                                        class="Latn" lang="sh"><a
+                                        href="https://en.wiktionary.org/w/index.php?title=hodala&amp;action=edit&amp;redlink=1"
+                                        class="new" title="hodala (page does not exist)">hodala</a></span>&nbsp;<span
+                                        class="gender"><abbr title="neuter gender">n</abbr></span>
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td colspan="8" style="text-align:left;"><sup>1</sup> &nbsp; Croatian spelling: others
+                                    omit the infinitive suffix completely and bind the clitic.<br><sup>2</sup> &nbsp;
+                                    For masculine nouns; a feminine or neuter agent would use the feminine and neuter
+                                    gender forms of the active past participle and auxiliary verb,
+                                    respectively.<br><sup>3</sup> &nbsp; Often replaced by the past perfect in
+                                    colloquial speech, i.e. the auxiliary verb <i><a
+                                            href="https://en.wiktionary.org/wiki/biti" title="biti">biti</a></i> (to be)
+                                    is routinely dropped.
+                                    <p><sup>4</sup> &nbsp; Often replaced by the conditional I in colloquial speech,
+                                        i.e. the auxiliary verb <i><a href="https://en.wiktionary.org/wiki/biti"
+                                                                      title="biti">biti</a></i> (to be) is routinely
+                                        dropped.
+                                        <br>&nbsp; * Note: The aorist and imperfect have nowadays fallen into disuse in
+                                        many dialects and therefore they are routinely replaced by the past perfect in
+                                        both formal and colloquial speech.
+                                    </p>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <h4><span class="mw-headline" id="Synonyms">Synonyms</span><span class="mw-editsection"><span
+                        class="mw-editsection-bracket">[</span><a
+                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;action=edit&amp;section=6"
+                        title="Edit section: Synonyms">edit</a><span class="mw-editsection-bracket">]</span></span></h4>
+                <ul>
+                    <li><span class="ib-brac">(</span><span class="ib-content"><a
+                            href="https://en.wikipedia.org/wiki/Croatia" class="extiw"
+                            title="w:Croatia">Croatia</a></span><span class="ib-brac">)</span> <span class="Latn"
+                                                                                                     lang="sh"><a
+                            href="https://en.wiktionary.org/w/index.php?title=%C4%8Depati&amp;action=edit&amp;redlink=1"
+                            class="new" title="čepati (page does not exist)">čepati</a></span></li>
+                </ul>
+                <h4><span class="mw-headline" id="Derived_terms">Derived terms</span><span class="mw-editsection"><span
+                        class="mw-editsection-bracket">[</span><a
+                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;action=edit&amp;section=7"
+                        title="Edit section: Derived terms">edit</a><span class="mw-editsection-bracket">]</span></span>
+                </h4>
+                <div class="derivedterms"
+                     style="column-count: 2; -moz-column-count: 2; -ms-column-count: 2; -o-column-count: 2; -webkit-column-count: 2;;">
+                    <ul>
+                        <li><span class="Latn" lang="sh"><a
+                                href="https://en.wiktionary.org/w/index.php?title=dohodati&amp;action=edit&amp;redlink=1"
+                                class="new" title="dohodati (page does not exist)">dohódati</a></span></li>
+                        <li><span class="Latn" lang="sh"><a
+                                href="https://en.wiktionary.org/w/index.php?title=nahodati&amp;action=edit&amp;redlink=1"
+                                class="new" title="nahodati (page does not exist)">nahódati</a></span></li>
+                        <li><span class="Latn" lang="sh"><a
+                                href="https://en.wiktionary.org/w/index.php?title=prehodati&amp;action=edit&amp;redlink=1"
+                                class="new" title="prehodati (page does not exist)">prehódati</a></span></li>
+                    </ul>
+                    <ul>
+                        <li><span class="Latn" lang="sh"><a
+                                href="https://en.wiktionary.org/w/index.php?title=prohodati&amp;action=edit&amp;redlink=1"
+                                class="new" title="prohodati (page does not exist)">prohódati</a></span></li>
+                        <li><span class="Latn" lang="sh"><a
+                                href="https://en.wiktionary.org/w/index.php?title=rashodati&amp;action=edit&amp;redlink=1"
+                                class="new" title="rashodati (page does not exist)">rashódati</a></span></li>
+                        <li><span class="Latn" lang="sh"><a
+                                href="https://en.wiktionary.org/w/index.php?title=uhodati&amp;action=edit&amp;redlink=1"
+                                class="new" title="uhodati (page does not exist)">uhódati</a></span></li>
+                        <li><span class="Latn" lang="sh"><a
+                                href="https://en.wiktionary.org/w/index.php?title=ushodati&amp;action=edit&amp;redlink=1"
+                                class="new" title="ushodati (page does not exist)">ushódati</a></span></li>
+                    </ul>
+                </div>
+                <h4><span class="mw-headline" id="Related_terms">Related terms</span><span class="mw-editsection"><span
+                        class="mw-editsection-bracket">[</span><a
+                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;action=edit&amp;section=8"
+                        title="Edit section: Related terms">edit</a><span class="mw-editsection-bracket">]</span></span>
+                </h4>
+                <ul>
+                    <li><span class="Latn" lang="sh"><a href="https://en.wiktionary.org/wiki/hoditi#Serbo-Croatian"
+                                                        title="hoditi">hòditi</a></span></li>
+                </ul>
+                <!--
+NewPP limit report
+Parsed by mw1407
+Cached time: 20211004021357
+Cache expiry: 1814400
+Reduced expiry: false
+Complications: []
+CPU time usage: 0.437 seconds
+Real time usage: 0.533 seconds
+Preprocessor visited node count: 6399/1000000
+Post‐expand include size: 37910/2097152 bytes
+Template argument size: 1261/2097152 bytes
+Highest expansion depth: 10/40
+Expensive parser function count: 0/500
+Unstrip recursion depth: 0/20
+Unstrip post‐expand size: 0/5000000 bytes
+Lua time usage: 0.252/10.000 seconds
+Lua memory usage: 11425272/52428800 bytes
+Number of Wikibase entities loaded: 0/400
+-->
+                <!--
+Transclusion expansion time report (%,ms,calls,template)
+100.00%  474.572      1 -total
+ 33.36%  158.331      1 Template:sh-conj
+ 28.17%  133.691     76 Template:l-self
+ 16.22%   76.959      6 Template:lb
+ 15.72%   74.599      2 Template:m
+ 11.31%   53.688      9 Template:l
+  9.02%   42.802     11 Template:redlink_category
+  8.70%   41.308      1 Template:sh-verb
+  6.88%   32.654      2 Template:check_deprecated_lang_param_usage
+  6.59%   31.279      1 Template:IPA
+-->
+
+                <!-- Saved in parser cache with key enwiktionary:pcache:idhash:816174-0!canonical and timestamp 20211004021356 and revision id 60892603. Serialized with JSON.
+ -->
+            </div>
+            <noscript><img src="//en.wiktionary.org/wiki/Special:CentralAutoLogin/start?type=1x1" alt="" title=""
+                           width="1" height="1" style="border: none; position: absolute;"/></noscript>
+            <div class="printfooter">Retrieved from "<a dir="ltr"
+                                                        href="https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603">https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603</a>"
+            </div>
+        </div>
+        <div id="catlinks" class="catlinks" data-mw="interface">
+            <div id="mw-normal-catlinks" class="mw-normal-catlinks"><a
+                    href="https://en.wiktionary.org/wiki/Special:Categories" title="Special:Categories">Categories</a>:
+                <ul>
+                    <li><a href="https://en.wiktionary.org/wiki/Category:Serbo-Croatian_terms_with_IPA_pronunciation"
+                           title="Category:Serbo-Croatian terms with IPA pronunciation">Serbo-Croatian terms with IPA
+                        pronunciation</a></li>
+                    <li><a href="https://en.wiktionary.org/wiki/Category:Serbo-Croatian_lemmas"
+                           title="Category:Serbo-Croatian lemmas">Serbo-Croatian lemmas</a></li>
+                    <li><a href="https://en.wiktionary.org/wiki/Category:Serbo-Croatian_verbs"
+                           title="Category:Serbo-Croatian verbs">Serbo-Croatian verbs</a></li>
+                    <li><a href="https://en.wiktionary.org/wiki/Category:Serbo-Croatian_imperfective_verbs"
+                           title="Category:Serbo-Croatian imperfective verbs">Serbo-Croatian imperfective verbs</a></li>
+                    <li><a href="https://en.wiktionary.org/wiki/Category:Serbo-Croatian_intransitive_verbs"
+                           title="Category:Serbo-Croatian intransitive verbs">Serbo-Croatian intransitive verbs</a></li>
+                    <li><a href="https://en.wiktionary.org/wiki/Category:Serbo-Croatian_informal_terms"
+                           title="Category:Serbo-Croatian informal terms">Serbo-Croatian informal terms</a></li>
+                    <li><a href="https://en.wiktionary.org/wiki/Category:Croatian_Serbo-Croatian"
+                           title="Category:Croatian Serbo-Croatian">Croatian Serbo-Croatian</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div id="mw-navigation">
+    <h2>Navigation menu</h2>
+    <div id="mw-head">
+        <nav id="p-personal" class="mw-portlet mw-portlet-personal vector-user-menu-legacy vector-menu"
+             aria-labelledby="p-personal-label" role="navigation">
+            <h3 id="p-personal-label" aria-label="" class="vector-menu-heading">
+
+                <span>Personal tools</span>
+            </h3>
+            <div class="vector-menu-content">
+
+                <ul class="vector-menu-content-list">
+                    <li id="pt-anonuserpage" class="mw-list-item"><span>Not logged in</span></li>
+                    <li id="pt-anontalk" class="mw-list-item"><a href="https://en.wiktionary.org/wiki/Special:MyTalk"
+                                                                 title="Discussion about edits from this IP address [alt-shift-n]"
+                                                                 accesskey="n"><span>Talk</span></a></li>
+                    <li id="pt-anoncontribs" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/wiki/Special:MyContributions"
+                            title="A list of edits made from this IP address [alt-shift-y]" accesskey="y"><span>Contributions</span></a>
+                    </li>
+                    <li class="mw-list-item mw-list-item-js" id="pt-agprefs"><a
+                            href="https://en.wiktionary.org/wiki/Wiktionary:Preferences/V2"
+                            title="Personalise Wiktionary (settings are kept per-browser)."><span>Preferences</span></a>
+                    </li>
+                    <li id="pt-createaccount" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/w/index.php?title=Special:CreateAccount&amp;returnto=hodati&amp;returntoquery=oldid%3D60892603"
+                            title="You are encouraged to create an account and log in; however, it is not mandatory"><span>Create account</span></a>
+                    </li>
+                    <li id="pt-login" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/w/index.php?title=Special:UserLogin&amp;returnto=hodati&amp;returntoquery=oldid%3D60892603"
+                            title="You are encouraged to log in; however, it is not mandatory [alt-shift-o]"
+                            accesskey="o"><span>Log in</span></a></li>
+                </ul>
+
+            </div>
+        </nav>
+
+        <div id="left-navigation">
+            <nav id="p-namespaces" class="mw-portlet mw-portlet-namespaces vector-menu vector-menu-tabs"
+                 aria-labelledby="p-namespaces-label" role="navigation">
+                <h3 id="p-namespaces-label" aria-label="" class="vector-menu-heading">
+
+                    <span>Namespaces</span>
+                </h3>
+                <div class="vector-menu-content">
+
+                    <ul class="vector-menu-content-list">
+                        <li id="ca-nstab-main" class="selected mw-list-item"><a
+                                href="https://en.wiktionary.org/wiki/hodati" title="View the content page [alt-shift-c]"
+                                accesskey="c"><span>Entry</span></a></li>
+                        <li id="ca-talk" class="new mw-list-item"><a
+                                href="https://en.wiktionary.org/w/index.php?title=Talk:hodati&amp;action=edit&amp;redlink=1"
+                                rel="discussion"
+                                title="Discussion about the content page (page does not exist) [alt-shift-t]"
+                                accesskey="t"><span>Discussion</span></a></li>
+                        <li class="mw-list-item mw-list-item-js new" id="ca-nstab-citations"><a
+                                href="https://en.wiktionary.org/w/index.php?title=Citations:hodati&amp;action=edit&amp;redlink=1"
+                                title="View the citations page [alt-shift-3]" accesskey="3"><span>Citations</span></a>
+                        </li>
+                    </ul>
+
+                </div>
+            </nav>
+
+            <nav id="p-variants"
+                 class="mw-portlet mw-portlet-variants emptyPortlet vector-menu-dropdown-noicon vector-menu vector-menu-dropdown"
+                 aria-labelledby="p-variants-label" role="navigation">
+                <input type="checkbox" id="p-variants-checkbox" role="button" aria-haspopup="true"
+                       data-event-name="ui.dropdown-p-variants" class=" vector-menu-checkbox"
+                       aria-labelledby="p-variants-label">
+                <h3 id="p-variants-label" aria-label="Change language variant" class="vector-menu-heading">
+
+                    <span>Variants</span>
+                    <span class="vector-menu-checkbox-expanded">expanded</span>
+                    <span class="vector-menu-checkbox-collapsed">collapsed</span>
+                </h3>
+                <div class="vector-menu-content">
+
+                    <ul class="vector-menu-content-list"></ul>
+
+                </div>
+            </nav>
+
+        </div>
+        <div id="right-navigation">
+            <nav id="p-views" class="mw-portlet mw-portlet-views vector-menu vector-menu-tabs"
+                 aria-labelledby="p-views-label" role="navigation">
+                <h3 id="p-views-label" aria-label="" class="vector-menu-heading">
+
+                    <span>Views</span>
+                </h3>
+                <div class="vector-menu-content">
+
+                    <ul class="vector-menu-content-list">
+                        <li id="ca-view" class="selected mw-list-item collapsible"><a
+                                href="https://en.wiktionary.org/wiki/hodati"><span>Read</span></a></li>
+                        <li id="ca-edit" class="mw-list-item collapsible"><a
+                                href="https://en.wiktionary.org/w/index.php?title=hodati&amp;action=edit"
+                                title="Edit this page [alt-shift-e]" accesskey="e"><span>Edit</span></a></li>
+                        <li id="ca-history" class="mw-list-item collapsible"><a
+                                href="https://en.wiktionary.org/w/index.php?title=hodati&amp;action=history"
+                                title="Past revisions of this page [alt-shift-h]" accesskey="h"><span>History</span></a>
+                        </li>
+                    </ul>
+
+                </div>
+            </nav>
+
+            <nav id="p-cactions"
+                 class="mw-portlet mw-portlet-cactions emptyPortlet vector-menu-dropdown-noicon vector-menu vector-menu-dropdown"
+                 aria-labelledby="p-cactions-label" role="navigation" title="More options">
+                <input type="checkbox" id="p-cactions-checkbox" role="button" aria-haspopup="true"
+                       data-event-name="ui.dropdown-p-cactions" class=" vector-menu-checkbox"
+                       aria-labelledby="p-cactions-label">
+                <h3 id="p-cactions-label" aria-label="" class="vector-menu-heading">
+
+                    <span>More</span>
+                    <span class="vector-menu-checkbox-expanded">expanded</span>
+                    <span class="vector-menu-checkbox-collapsed">collapsed</span>
+                </h3>
+                <div class="vector-menu-content">
+
+                    <ul class="vector-menu-content-list"></ul>
+
+                </div>
+            </nav>
+
+            <div id="p-search" role="search" class=" vector-search-box">
+                <div>
+                    <h3>
+                        <label for="searchInput">Search</label>
+                    </h3>
+                    <form action="https://en.wiktionary.org/w/index.php" id="searchform" class="vector-search-box-form">
+                        <div id="simpleSearch" class="vector-search-box-inner" data-search-loc="header-navigation">
+                            <input class="vector-search-box-input" type="search" name="search"
+                                   placeholder="Search Wiktionary" autocapitalize="none"
+                                   title="Search Wiktionary [alt-shift-f]" accesskey="f" id="searchInput">
+                            <input type="hidden" name="title" value="Special:Search">
+                            <input id="mw-searchButton" class="searchButton mw-fallbackSearchButton" type="submit"
+                                   name="fulltext" title="Search the pages for this text" value="Search">
+                            <input id="searchButton" class="searchButton" type="submit" name="go"
+                                   title="Go to a page with this exact name if it exists" value="Go">
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+    <div id="mw-panel">
+        <div id="p-logo" role="banner">
+            <a class="mw-wiki-logo" href="https://en.wiktionary.org/wiki/Wiktionary:Main_Page"
+               title="Visit the main page"></a>
+        </div>
+        <nav id="p-navigation" class="mw-portlet mw-portlet-navigation vector-menu vector-menu-portal portal"
+             aria-labelledby="p-navigation-label" role="navigation">
+            <h3 id="p-navigation-label" aria-label="" class="vector-menu-heading">
+
+                <span>Navigation</span>
+            </h3>
+            <div class="vector-menu-content">
+
+                <ul class="vector-menu-content-list">
+                    <li id="n-mainpage-text" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/wiki/Wiktionary:Main_Page"><span>Main Page</span></a></li>
+                    <li id="n-portal" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/wiki/Wiktionary:Community_portal"
+                            title="About the project, what you can do, where to find things"><span>Community portal</span></a>
+                    </li>
+                    <li id="n-wiktprefs" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/wiki/Wiktionary:Per-browser_preferences"><span>Preferences</span></a>
+                    </li>
+                    <li id="n-requestedarticles" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/wiki/Wiktionary:Requested_entries"><span>Requested entries</span></a>
+                    </li>
+                    <li id="n-recentchanges" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/wiki/Special:RecentChanges"
+                            title="A list of recent changes in the wiki [alt-shift-r]" accesskey="r"><span>Recent changes</span></a>
+                    </li>
+                    <li id="n-randompage" class="mw-list-item"><a href="https://en.wiktionary.org/wiki/Special:Random"
+                                                                  title="Load a random page [alt-shift-x]"
+                                                                  accesskey="x"><span>Random entry</span></a></li>
+                    <li id="n-help" class="mw-list-item"><a href="https://en.wiktionary.org/wiki/Help:Contents"
+                                                            title="The place to find out"><span>Help</span></a></li>
+                    <li id="n-Glossary" class="mw-list-item"><a href="https://en.wiktionary.org/wiki/Appendix:Glossary"><span>Glossary</span></a>
+                    </li>
+                    <li id="n-sitesupport" class="mw-list-item"><a
+                            href="https://donate.wikimedia.org/wiki/Special:FundraiserRedirector?utm_source=donate&amp;utm_medium=sidebar&amp;utm_campaign=C13_en.wiktionary.org&amp;uselang=en"
+                            title="Support us"><span>Donations</span></a></li>
+                    <li id="n-contact" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/wiki/Wiktionary:Contact_us"><span>Contact us</span></a></li>
+                </ul>
+
+            </div>
+        </nav>
+
+        <nav id="p-tb" class="mw-portlet mw-portlet-tb vector-menu vector-menu-portal portal"
+             aria-labelledby="p-tb-label" role="navigation">
+            <h3 id="p-tb-label" aria-label="" class="vector-menu-heading">
+
+                <span>Tools</span>
+            </h3>
+            <div class="vector-menu-content">
+
+                <ul class="vector-menu-content-list">
+                    <li id="t-whatlinkshere" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/wiki/Special:WhatLinksHere/hodati"
+                            title="A list of all wiki pages that link here [alt-shift-j]" accesskey="j"><span>What links here</span></a>
+                    </li>
+                    <li id="t-recentchangeslinked" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/wiki/Special:RecentChangesLinked/hodati" rel="nofollow"
+                            title="Recent changes in pages linked from this page [alt-shift-k]" accesskey="k"><span>Related changes</span></a>
+                    </li>
+                    <li id="t-upload" class="mw-list-item"><a
+                            href="https://commons.wikimedia.org/wiki/Special:UploadWizard?uselang=en"
+                            title="Upload files [alt-shift-u]" accesskey="u"><span>Upload file</span></a></li>
+                    <li id="t-specialpages" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/wiki/Special:SpecialPages"
+                            title="A list of all special pages [alt-shift-q]"
+                            accesskey="q"><span>Special pages</span></a></li>
+                    <li id="t-permalink" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603"
+                            title="Permanent link to this revision of the page"><span>Permanent link</span></a></li>
+                    <li id="t-info" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/w/index.php?title=hodati&amp;action=info"
+                            title="More information about this page"><span>Page information</span></a></li>
+                    <li id="t-cite" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/w/index.php?title=Special:CiteThisPage&amp;page=hodati&amp;id=60892603&amp;wpFormIdentifier=titleform"
+                            title="Information on how to cite this page"><span>Cite this page</span></a></li>
+                </ul>
+
+            </div>
+        </nav>
+        <nav id="p-coll-print_export"
+             class="mw-portlet mw-portlet-coll-print_export vector-menu vector-menu-portal portal"
+             aria-labelledby="p-coll-print_export-label" role="navigation">
+            <h3 id="p-coll-print_export-label" aria-label="" class="vector-menu-heading">
+
+                <span>Print/export</span>
+            </h3>
+            <div class="vector-menu-content">
+
+                <ul class="vector-menu-content-list">
+                    <li id="coll-create_a_book" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/w/index.php?title=Special:Book&amp;bookcmd=book_creator&amp;referer=hodati"><span>Create a book</span></a>
+                    </li>
+                    <li id="coll-download-as-rl" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/w/index.php?title=Special:DownloadAsPdf&amp;page=hodati&amp;action=show-download-screen"><span>Download as PDF</span></a>
+                    </li>
+                    <li id="t-print" class="mw-list-item"><a
+                            href="https://en.wiktionary.org/w/index.php?title=hodati&amp;printable=yes"
+                            title="Printable version of this page [alt-shift-p]"
+                            accesskey="p"><span>Printable version</span></a></li>
+                </ul>
+
+            </div>
+        </nav>
+
+        <div class="vector-menu vector-menu-portal portal portlet" id="p-visibility"><h3>Visibility</h3>
+            <div class="pBody body vector-menu-content">
+                <ul>
+                    <li><a id="p-visibility-conjugation"
+                           href="https://en.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603#visibility-conjugation">Show
+                        conjugation</a></li>
+                </ul>
+            </div>
+        </div>
+        <nav id="p-lang" class="mw-portlet mw-portlet-lang vector-menu vector-menu-portal portal"
+             aria-labelledby="p-lang-label" role="navigation">
+            <button class="uls-settings-trigger" title="Language settings"></button>
+            <h3 id="p-lang-label" aria-label="" class="vector-menu-heading">
+
+                <span>In other languages</span>
+            </h3>
+            <div class="vector-menu-content">
+
+                <ul class="vector-menu-content-list">
+                    <li class="interlanguage-link interwiki-eu mw-list-item" style="display: none;"><a
+                            href="https://eu.wiktionary.org/wiki/hodati" title="hodati – Basque" lang="eu" hreflang="eu"
+                            class="interlanguage-link-target"><span>Euskara</span></a></li>
+                    <li class="interlanguage-link interwiki-fr mw-list-item" style=""><a
+                            href="https://fr.wiktionary.org/wiki/hodati" title="hodati – French" lang="fr" hreflang="fr"
+                            class="interlanguage-link-target"><span>Français</span></a></li>
+                    <li class="interlanguage-link interwiki-hr mw-list-item" style=""><a
+                            href="https://hr.wiktionary.org/wiki/hodati" title="hodati – Croatian" lang="hr"
+                            hreflang="hr" class="interlanguage-link-target"><span>Hrvatski</span></a></li>
+                    <li class="interlanguage-link interwiki-hu mw-list-item" style=""><a
+                            href="https://hu.wiktionary.org/wiki/hodati" title="hodati – Hungarian" lang="hu"
+                            hreflang="hu" class="interlanguage-link-target"><span>Magyar</span></a></li>
+                    <li class="interlanguage-link interwiki-pl mw-list-item" style=""><a
+                            href="https://pl.wiktionary.org/wiki/hodati" title="hodati – Polish" lang="pl" hreflang="pl"
+                            class="interlanguage-link-target"><span>Polski</span></a></li>
+                    <li class="interlanguage-link interwiki-sr mw-list-item" style="display: none;"><a
+                            href="https://sr.wiktionary.org/wiki/hodati" title="hodati – Serbian" lang="sr"
+                            hreflang="sr" class="interlanguage-link-target"><span>Српски / srpski</span></a></li>
+                    <li class="interlanguage-link interwiki-sh mw-list-item" style=""><a
+                            href="https://sh.wiktionary.org/wiki/hodati" title="hodati – Serbo-Croatian" lang="sh"
+                            hreflang="sh" class="interlanguage-link-target"><span>Srpskohrvatski / српскохрватски</span></a>
+                    </li>
+                    <li class="interlanguage-link interwiki-fi mw-list-item" style="display: none;"><a
+                            href="https://fi.wiktionary.org/wiki/hodati" title="hodati – Finnish" lang="fi"
+                            hreflang="fi" class="interlanguage-link-target"><span>Suomi</span></a></li>
+                    <li class="interlanguage-link interwiki-sv mw-list-item" style=""><a
+                            href="https://sv.wiktionary.org/wiki/hodati" title="hodati – Swedish" lang="sv"
+                            hreflang="sv" class="interlanguage-link-target"><span>Svenska</span></a></li>
+                    <li class="interlanguage-link interwiki-tr mw-list-item" style=""><a
+                            href="https://tr.wiktionary.org/wiki/hodati" title="hodati – Turkish" lang="tr"
+                            hreflang="tr" class="interlanguage-link-target"><span>Türkçe</span></a></li>
+                    <button class="mw-interlanguage-selector mw-ui-button"
+                            title="All languages (initial selection from common choices by you and others)">3 more
+                    </button>
+                </ul>
+
+            </div>
+        </nav>
+
+        <div class="portal expanded" id="p-feedback">
+            <div class="body"><p style="font-size: 80%;"><a
+                    href="https://en.wiktionary.org/w/index.php?title=Wiktionary:Feedback&amp;action=edit&amp;section=new&amp;preload=Wiktionary%3AFeedback%2Fpreload&amp;editintro=Wiktionary%3AFeedback%2Fintro&amp;preloadtitle=%5B%5B%3Ahodati%5D%5D">If
+                you have time, leave us a note.</a></p></div>
+        </div>
+    </div>
+
+</div>
+<footer id="footer" class="mw-footer" role="contentinfo">
+    <ul id="footer-info">
+        <li id="footer-info-lastmod"> This page was last edited on 21 October 2020, at 02:19.</li>
+        <li id="footer-info-copyright">Text is available under the <a
+                href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike
+            License</a>; additional terms may apply. By using this site, you agree to the <a
+                href="https://wikimediafoundation.org/wiki/Terms_of_Use">Terms of Use</a> and <a
+                href="https://wikimediafoundation.org/wiki/Privacy_policy">Privacy Policy.</a></li>
+    </ul>
+
+    <ul id="footer-places">
+        <li id="footer-places-privacy"><a href="https://foundation.wikimedia.org/wiki/Privacy_policy" class="extiw"
+                                          title="wmf:Privacy policy">Privacy policy</a></li>
+        <li id="footer-places-about"><a href="https://en.wiktionary.org/wiki/Wiktionary:About" class="mw-redirect"
+                                        title="Wiktionary:About">About&nbsp;Wiktionary</a></li>
+        <li id="footer-places-disclaimer"><a href="https://en.wiktionary.org/wiki/Wiktionary:General_disclaimer"
+                                             title="Wiktionary:General disclaimer">Disclaimers</a></li>
+        <li id="footer-places-mobileview"><a
+                href="https://en.m.wiktionary.org/w/index.php?title=hodati&amp;oldid=60892603&amp;mobileaction=toggle_view_mobile"
+                class="noprint stopMobileRedirectToggle">Mobile view</a></li>
+        <li id="footer-places-developers"><a href="https://www.mediawiki.org/wiki/Special:MyLanguage/How_to_contribute">Developers</a>
+        </li>
+        <li id="footer-places-statslink"><a href="https://stats.wikimedia.org/#/en.wiktionary.org">Statistics</a></li>
+        <li id="footer-places-cookiestatement"><a href="https://foundation.wikimedia.org/wiki/Cookie_statement">Cookie
+            statement</a></li>
+    </ul>
+
+    <ul id="footer-icons" class="noprint">
+        <li id="footer-copyrightico"><a href="https://wikimediafoundation.org/"><img
+                src="./hodati-60892603_files/wikimedia-button.png"
+                srcset="/static/images/footer/wikimedia-button-1.5x.png 1.5x, /static/images/footer/wikimedia-button-2x.png 2x"
+                width="88" height="31" alt="Wikimedia Foundation" loading="lazy"></a></li>
+        <li id="footer-poweredbyico"><a href="https://www.mediawiki.org/"><img
+                src="./hodati-60892603_files/poweredby_mediawiki_88x31.png" alt="Powered by MediaWiki"
+                srcset="/static/images/footer/poweredby_mediawiki_132x47.png 1.5x, /static/images/footer/poweredby_mediawiki_176x62.png 2x"
+                width="88" height="31" loading="lazy"></a></li>
+    </ul>
+
+</footer>
+
+
+<script>(RLQ = window.RLQ || []).push(function () {
+    mw.config.set({
+        "wgPageParseReport": {
+            "limitreport": {
+                "cputime": "0.437",
+                "walltime": "0.533",
+                "ppvisitednodes": {"value": 6399, "limit": 1000000},
+                "postexpandincludesize": {"value": 37910, "limit": 2097152},
+                "templateargumentsize": {"value": 1261, "limit": 2097152},
+                "expansiondepth": {"value": 10, "limit": 40},
+                "expensivefunctioncount": {"value": 0, "limit": 500},
+                "unstrip-depth": {"value": 0, "limit": 20},
+                "unstrip-size": {"value": 0, "limit": 5000000},
+                "entityaccesscount": {"value": 0, "limit": 400},
+                "timingprofile": ["100.00%  474.572      1 -total", " 33.36%  158.331      1 Template:sh-conj", " 28.17%  133.691     76 Template:l-self", " 16.22%   76.959      6 Template:lb", " 15.72%   74.599      2 Template:m", " 11.31%   53.688      9 Template:l", "  9.02%   42.802     11 Template:redlink_category", "  8.70%   41.308      1 Template:sh-verb", "  6.88%   32.654      2 Template:check_deprecated_lang_param_usage", "  6.59%   31.279      1 Template:IPA"]
+            },
+            "scribunto": {
+                "limitreport-timeusage": {"value": "0.252", "limit": "10.000"},
+                "limitreport-memusage": {"value": 11425272, "limit": 52428800}
+            },
+            "cachereport": {
+                "origin": "mw1407",
+                "timestamp": "20211004021357",
+                "ttl": 1814400,
+                "transientcontent": false
+            }
+        }
+    });
+    mw.config.set({"wgBackendResponseTime": 118, "wgHostname": "mw1403"});
+});</script>
+<script>mendeleyWebImporter = {
+    downloadPdfs(t, e) {
+        return this._call('downloadPdfs', [t, e]);
+    },
+    open() {
+        return this._call('open', []);
+    },
+    setLoginToken(t) {
+        return this._call('setLoginToken', [t]);
+    },
+    _call(methodName, methodArgs) {
+        const id = Math.random();
+        window.postMessage({id, token: '0.8602301747845553', methodName, methodArgs}, 'https://en.wiktionary.org');
+        return new Promise(resolve => {
+            const listener = window.addEventListener('message', event => {
+                const data = event.data;
+                if (typeof data !== 'object' || !('result' in data) || data.id !== id) return;
+                window.removeEventListener('message', listener);
+                resolve(data.result);
+            });
+        });
+    }
+};</script>
+</body>
+</html>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -108,8 +108,7 @@ class TestParserExtensions(unittest.TestCase):
     def test_custom_content_parser(self):
         custom_parser = WiktionaryParser()
         custom_parser.set_default_language('serbo-croatian')
-        conjugations_parser = serbocroatian.ConjugationsParser()
-        custom_parser.set_content_parser("conjugation", conjugations_parser)
+        custom_parser.set_content_parser("conjugation", serbocroatian.ConjugationsParser())
         custom_parser.add_post_processor(serbocroatian.ConjugationsProcessor())
         words = custom_parser.fetch("hodati", old_id=60892603)
         self.assertEqual(words[0]["conjugations"]["present"][0], "hodam")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ from parameterized import parameterized
 import unittest
 import json
 from wiktionaryparser import WiktionaryParser
+from wiktionaryparser.languages import serbocroatian
 from deepdiff import DeepDiff
 from typing import Dict, List
 import mock
@@ -9,7 +10,6 @@ from urllib import parse
 import os
 
 parser = WiktionaryParser()
-
 
 tests_dir = os.path.dirname(__file__)
 html_test_files_dir = os.path.join(tests_dir, 'html_test_files')
@@ -102,6 +102,17 @@ class TestParser(unittest.TestCase):
             print(json.dumps(fetched_word, indent=4))
 
         self.assertEqual(diff, {})
+
+
+class TestParserExtensions(unittest.TestCase):
+    def test_custom_content_parser(self):
+        custom_parser = WiktionaryParser()
+        custom_parser.set_default_language('serbo-croatian')
+        conjugations_parser = serbocroatian.ConjugationsParser()
+        custom_parser.set_content_parser("conjugation", conjugations_parser)
+        custom_parser.add_post_processor(serbocroatian.ConjugationsProcessor())
+        words = custom_parser.fetch("hodati", old_id=60892603)
+        self.assertEqual(words[0]["conjugations"]["present"][0], "hodam")
 
 
 if __name__ == '__main__':

--- a/wiktionaryparser/__init__.py
+++ b/wiktionaryparser/__init__.py
@@ -7,5 +7,6 @@ __all__ = [
     'RelatedWord',
     'PARTS_OF_SPEECH',
     'RELATIONS',
-    'WiktionaryParser'
+    'WiktionaryParser',
+    'languages'
 ]

--- a/wiktionaryparser/languages/serbocroatian.py
+++ b/wiktionaryparser/languages/serbocroatian.py
@@ -12,7 +12,8 @@ class ConjugationsParser(ContentParser):
             inflection_table = None
             while parent_tag and inflection_table is None:
                 parent_tag = parent_tag.find_next_sibling()
-                inflection_table = parent_tag.select_one('.inflection-table')
+                if parent_tag:
+                    inflection_table = parent_tag.select_one('.inflection-table')
 
             if not inflection_table:
                 return None
@@ -67,6 +68,9 @@ class ConjugationsParser(ContentParser):
 
 class ConjugationsProcessor(object):
     def process_word_data(self, words, word_data):
+        if "conjugation" not in word_data or not word_data['conjugation']:
+            return
+
         for word in words:
             for conjugation_index, conjugation in word_data['conjugation']:
                 if word.contains_heading(conjugation_index):

--- a/wiktionaryparser/languages/serbocroatian.py
+++ b/wiktionaryparser/languages/serbocroatian.py
@@ -1,0 +1,73 @@
+from wiktionaryparser.core import ContentParser
+
+
+class ConjugationsParser(ContentParser):
+    def parse_content(self, soup, language, word_contents):
+        conjugation_id_list = self.get_id_list(soup, word_contents, ["conjugation"])
+        conjugations_list = []
+        for conjugation_index, conjugation_id, conjugation_type in conjugation_id_list:
+            words = []
+            span_tag = soup.find_all('span', {'id': conjugation_id})[0]
+            parent_tag = span_tag.parent
+            inflection_table = None
+            while parent_tag and inflection_table is None:
+                parent_tag = parent_tag.find_next_sibling()
+                inflection_table = parent_tag.select_one('.inflection-table')
+
+            if not inflection_table:
+                return None
+
+            conjugations = dict()
+            infinitive_tag = inflection_table.find(lambda tag: tag.name == "b" and "Infinitive" in tag.text)
+            if infinitive_tag:
+                inf_container = infinitive_tag.select_one("strong")
+                if inf_container:
+                    conjugations["infinitive"] = inf_container.text
+
+                conjugations["present"] = self.parse_inflection_row(inflection_table, "Present")
+                conjugations["futur1"] = self.parse_inflection_row(inflection_table, "Future I")
+                conjugations["futur2"] = self.parse_inflection_row(inflection_table, "Future II")
+                conjugations["perfect"] = self.parse_inflection_row(inflection_table, "Perfect")
+                conjugations["pluperfect"] = self.parse_inflection_row(inflection_table, "Pluperfect")
+                conjugations["imperfect"] = self.parse_inflection_row(inflection_table, "Imperfect")
+                conjugations["conditional1"] = self.parse_inflection_row(inflection_table, "Conditional I")
+                conjugations["conditional2"] = self.parse_inflection_row(inflection_table, "Conditional II")
+                conjugations["imperative"] = self.parse_inflection_row(inflection_table, "Imperative")
+
+            conjugations_list.append((conjugation_index, conjugations))
+
+        return conjugations_list
+
+    def parse_inflection_row(self, inflection_table, row_name):
+        inflection_tag = inflection_table.find(lambda tag: tag.name == "b" and row_name == tag.text)
+        if not inflection_tag:
+            return None
+
+        inflection_form = inflection_tag.parent.find_next_sibling()
+        inflection_forms = []
+        while inflection_form:
+
+            children = []
+            child_forms = inflection_form.find_all("span", recursive=False)
+            for child_form in child_forms:
+                children.append(
+                    " ".join([t.strip() for t in child_form.find_all(text=True) if len(t) > 0 and not t.isspace()]))
+
+            if len(children) == 0:
+                inflection_forms.append(None)
+            elif len(children) == 1:
+                inflection_forms.append(children[0])
+            else:
+                inflection_forms.append(children)
+
+            inflection_form = inflection_form.find_next_sibling()
+
+        return inflection_forms
+
+
+class ConjugationsProcessor(object):
+    def process_word_data(self, words, word_data):
+        for word in words:
+            for conjugation_index, conjugation in word_data['conjugation']:
+                if word.contains_heading(conjugation_index):
+                    word.data["conjugations"] = conjugation

--- a/wiktionaryparser/utils.py
+++ b/wiktionaryparser/utils.py
@@ -1,37 +1,31 @@
+def count_digits(s):
+    return len(list(filter(str.isdigit, s)))
+
+
 class WordData(object):
-    def __init__(self, etymology=None, definitions=None, pronunciations=None,
-                 audio_links=None):
-        self.etymology = etymology if etymology else ''
-        self.definition_list = definitions
-        self.pronunciations = pronunciations if pronunciations else []
-        self.audio_links = audio_links if audio_links else []
+    def __init__(self, index, next_index):
+        self.index = index
+        self.next_index = next_index
+        self.data = dict()
 
-    @property
-    def definition_list(self):
-        return self._definition_list
+    def contains_heading(self, other_index):
+        current_index_str = ".".join(f"{int(num):02d}" for num in self.index.split(".") if num)
+        definition_index_str = ".".join(f"{int(num):02d}" for num in other_index.split(".") if num)
+        next_index_str = ".".join(f"{int(num):02d}" for num in self.next_index.split(".") if num)
+        return current_index_str <= definition_index_str < next_index_str
 
-    @definition_list.setter
-    def definition_list(self, definitions):
-        if definitions is None:
-            self._definition_list = []
-            return
-        elif not isinstance(definitions, list):
-            raise TypeError('Invalid type for definition')
-        else:
-            for element in definitions:
-                if not isinstance(element, Definition):
-                    raise TypeError('Invalid type for definition')
-            self._definition_list = definitions
+    def is_sibling_heading(self, other):
+        return count_digits(self.index) == count_digits(other)
 
-    def to_json(self):
-        return {
-            'etymology': self.etymology,
-            'definitions': [definition.to_json() for definition in self._definition_list],
-            'pronunciations': {
-                'text': self.pronunciations,
-                'audio': self.audio_links
-            }
-        }
+    def belongs_to_heading(self, parent):
+        child_headings = self.index.split(".")
+        parent_headings = parent.split(".")
+        if len(child_headings) <= len(parent_headings):
+            return False
+        for child_heading, parent_heading in zip(child_headings, parent_headings):
+            if child_heading != parent_heading:
+                return False
+        return True
 
 
 class Definition(object):


### PR DESCRIPTION
This PR includes
* a massive refactoring (almost a complete rewrite) to modularize WiktionaryParser. The API is still the same and clients should not notice any difference
* a parser for Serbo-Croatian conjugation tables (inflections)

Initially I just wanted to contribute the inflections parser. However, since the old code is quite convoluted I couldn't just easily add code. So I ended up refactoring WiktionaryParser and implemented the inflection parser/processor on top. The new parser serves as an example of how the parsing can be extended. Existing clients should not notice any difference, as the API was only exended, but no existing API was modified.

The new architecture is as follows: The HTML soup is parsed by an extensible list of parser objects (e.g. ExamplesParser, DefinitionsParser, etc.). Once the parsers have extracted the interesting data, processor objects transform the data into its final form (e.g. they try to correlate etymologies with their definitions, just like the original code did). I reused most of the original code for implementing the parsers. Parsing and processing the Serbo-Croatian inflection tables looks as follows:

```
custom_parser = WiktionaryParser()
custom_parser.set_default_language('serbo-croatian')
custom_parser.set_content_parser("conjugation", serbocroatian.ConjugationsParser())
custom_parser.add_post_processor(serbocroatian.ConjugationsProcessor())
words = custom_parser.fetch("hodati", old_id=60892603)
```

This architecture should allow implementing more language specific stuff without opening up the core code all the time. 