### PR TITLE
Fix classless div KeyError bug

### DIFF
--- a/wiktionaryparser/core.py
+++ b/wiktionaryparser/core.py
@@ -153,7 +153,8 @@ class WiktionaryParser(object):
                 if list_tag.name == 'p':
                     pronunciation_text.append(list_tag.text)
                     break
-                if list_tag.name == 'div' and any(_ in pronunciation_div_classes for _ in list_tag['class']):
+                list_tag_class = list_tag['class'] if "class" in list_tag else []
+                if list_tag.name == 'div' and any(_ in pronunciation_div_classes for _ in list_tag_class):
                     break
             for super_tag in list_tag.find_all('sup'):
                 super_tag.clear()


### PR DESCRIPTION
Current code results in key error when the div in this HTML doesn't have any classes. The class property isn't just an empty array when the div doesn't have a class, it's undefined. So I added an extra variable giving a default of an empty class.